### PR TITLE
chore(script): Mejorando validate.sh 2

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -24,9 +24,10 @@ do
         exit 1
     fi
 
-    echo "Detectando cambios en archivos '.tf'"
-    cambios=$(git status --porcelain *.tf)
-    if [ -n "$cambios" ]; then
+    echo "Detectando cambios en archivos '.tf' no confirmados"
+    #cambios=$(git status --porcelain *.tf)
+    git diff --name-only --exit-code "*.tf" >/dev/null
+    if [ $? -ne 0 ]; then
         echo "Hay cambios pendientes por confirmar"
         exit 1
     else


### PR DESCRIPTION
El script validate.sh siempre arrojaba cambios por confirmar. Lo he modificado para que revise solo cambios que no se han agregado al *Stagin Area*, con ello el script dara exito si los cambios en archivos `.tf` estan listos para commitear.

close #5 