### PR TITLE
Feature/rollback drift mitchel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,9 @@
 # **/.terraform/
 # **/.terraform.lock.hcl
 
-# servicios_simulados/
+servicios_simulados/
+
+logs/
 
 # Entorno virtual
 .venv/
@@ -16,3 +18,6 @@ PC3.md
 
 # BDD - en progreso
 features/
+
+# main.tf principal
+terraform/main.tf

--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,6 @@
 
 servicios_simulados/
 
-
-logs/
-
 # Entorno virtual
 .venv/
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 servicios_simulados/
 
+
 logs/
 
 # Entorno virtual

--- a/backups/v1_6_0/servicio_a/tfstate_v1.6.0.tfstate
+++ b/backups/v1_6_0/servicio_a/tfstate_v1.6.0.tfstate
@@ -1,0 +1,27 @@
+{
+  "version": 4,
+  "terraform_version": "1.12.1",
+  "serial": 1,
+  "lineage": "bbe75eea-6168-3b0b-8d7d-17ac97ee5f25",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "servicio_a",
+      "provider": "provider[\"registry.terraform.io/hashicorp/null\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "8771288233724656698",
+            "triggers": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0
+        }
+      ]
+    }
+  ],
+  "check_results": null
+}

--- a/backups/v1_6_0/servicio_b/tfstate_v1.6.0.tfstate
+++ b/backups/v1_6_0/servicio_b/tfstate_v1.6.0.tfstate
@@ -1,0 +1,70 @@
+{
+  "version": 4,
+  "terraform_version": "1.12.1",
+  "serial": 4,
+  "lineage": "12b86e99-50d0-b059-56c8-d3b1ed12b791",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "servicio_b",
+      "provider": "provider[\"registry.terraform.io/hashicorp/null\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "4364075706985955479",
+            "triggers": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "dependencies": [
+            "module.servicio_c.module.servicio_a.null_resource.servicio_a",
+            "module.servicio_c.null_resource.servicio_c"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.servicio_c",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "servicio_c",
+      "provider": "provider[\"registry.terraform.io/hashicorp/null\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "4655234923691359330",
+            "triggers": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "dependencies": [
+            "module.servicio_c.module.servicio_a.null_resource.servicio_a"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.servicio_c.module.servicio_a",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "servicio_a",
+      "provider": "provider[\"registry.terraform.io/hashicorp/null\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "8290191218549315080",
+            "triggers": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0
+        }
+      ]
+    }
+  ],
+  "check_results": null
+}

--- a/backups/v1_6_0/servicio_c/tfstate_v1.6.0.tfstate
+++ b/backups/v1_6_0/servicio_c/tfstate_v1.6.0.tfstate
@@ -1,0 +1,48 @@
+{
+  "version": 4,
+  "terraform_version": "1.12.1",
+  "serial": 3,
+  "lineage": "bc927bc3-aa48-2a05-a338-fbd74c67f61b",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "servicio_c",
+      "provider": "provider[\"registry.terraform.io/hashicorp/null\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "5189715582138057298",
+            "triggers": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "dependencies": [
+            "module.servicio_a.null_resource.servicio_a"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.servicio_a",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "servicio_a",
+      "provider": "provider[\"registry.terraform.io/hashicorp/null\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "7594903794493526689",
+            "triggers": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0
+        }
+      ]
+    }
+  ],
+  "check_results": null
+}

--- a/backups/v1_6_0/servicio_d/tfstate_v1.6.0.tfstate
+++ b/backups/v1_6_0/servicio_d/tfstate_v1.6.0.tfstate
@@ -1,0 +1,93 @@
+{
+  "version": 4,
+  "terraform_version": "1.12.1",
+  "serial": 5,
+  "lineage": "0d12cb95-1416-4f46-8107-b28178cd7ae3",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "servicio_d",
+      "provider": "provider[\"registry.terraform.io/hashicorp/null\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "3446376636890549700",
+            "triggers": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "dependencies": [
+            "module.servicio_b.module.servicio_c.module.servicio_a.null_resource.servicio_a",
+            "module.servicio_b.module.servicio_c.null_resource.servicio_c",
+            "module.servicio_b.null_resource.servicio_b"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.servicio_b",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "servicio_b",
+      "provider": "provider[\"registry.terraform.io/hashicorp/null\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "7760375672855320056",
+            "triggers": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "dependencies": [
+            "module.servicio_b.module.servicio_c.module.servicio_a.null_resource.servicio_a",
+            "module.servicio_b.module.servicio_c.null_resource.servicio_c"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.servicio_b.module.servicio_c",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "servicio_c",
+      "provider": "provider[\"registry.terraform.io/hashicorp/null\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "4453232201833176036",
+            "triggers": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "dependencies": [
+            "module.servicio_b.module.servicio_c.module.servicio_a.null_resource.servicio_a"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.servicio_b.module.servicio_c.module.servicio_a",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "servicio_a",
+      "provider": "provider[\"registry.terraform.io/hashicorp/null\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "2258264413017640814",
+            "triggers": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0
+        }
+      ]
+    }
+  ],
+  "check_results": null
+}

--- a/backups/v1_7_0/servicio_a/tfstate_v1.7.0.tfstate
+++ b/backups/v1_7_0/servicio_a/tfstate_v1.7.0.tfstate
@@ -1,0 +1,63 @@
+{
+  "version": 4,
+  "terraform_version": "1.12.1",
+  "serial": 5,
+  "lineage": "bbe75eea-6168-3b0b-8d7d-17ac97ee5f25",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "local_file",
+      "name": "servicio_dummy",
+      "provider": "provider[\"registry.terraform.io/hashicorp/local\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "content": "Servicio creado a las 2025-06-18 23:42:44",
+            "content_base64": null,
+            "content_base64sha256": "dQUwuD/hqvLK2YMWLAzUzQBmCMSwvRMc3u7rIC9HO14=",
+            "content_base64sha512": "csBBwVlNOF/vZE2/Y2/r+vHswxoJZ9IqfTWFrKCkU6l+33zm8K/+NJqAS0TNBhg1N1YZQ21j8ll9WNVOA1hCcw==",
+            "content_md5": "762287d06659477dcf26230252d0d91d",
+            "content_sha1": "027f0369ab1119b9be3f41880668702b6d473e63",
+            "content_sha256": "750530b83fe1aaf2cad983162c0cd4cd006608c4b0bd131cdeeeeb202f473b5e",
+            "content_sha512": "72c041c1594d385fef644dbf636febfaf1ecc31a0967d22a7d3585aca0a453a97edf7ce6f0affe349a804b44cd061835375619436d63f2597d58d54e03584273",
+            "directory_permission": "0777",
+            "file_permission": "0777",
+            "filename": "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service",
+            "id": "027f0369ab1119b9be3f41880668702b6d473e63",
+            "sensitive_content": null,
+            "source": null
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "sensitive_content"
+              }
+            ]
+          ],
+          "identity_schema_version": 0
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "servicio_a",
+      "provider": "provider[\"registry.terraform.io/hashicorp/null\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "8771288233724656698",
+            "triggers": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0
+        }
+      ]
+    }
+  ],
+  "check_results": null
+}

--- a/backups/v1_7_0/servicio_b/tfstate_v1.7.0.tfstate
+++ b/backups/v1_7_0/servicio_b/tfstate_v1.7.0.tfstate
@@ -1,0 +1,183 @@
+{
+  "version": 4,
+  "terraform_version": "1.12.1",
+  "serial": 12,
+  "lineage": "12b86e99-50d0-b059-56c8-d3b1ed12b791",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "local_file",
+      "name": "servicio_dummy",
+      "provider": "provider[\"registry.terraform.io/hashicorp/local\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "content": "Servicio creado a las 2025-06-18 23:42:47",
+            "content_base64": null,
+            "content_base64sha256": "62CfQur2e51Bih/AM8FN0iEUlMx5FRulcCaA+QJZTPg=",
+            "content_base64sha512": "Jw+SF+VCsE8xlHgDubxQ2pIHn4RYYWga2m2j7VlToRv1ipUN4UKWB7fagWRxAZ480TJvkSO3ijEw3AiKSjCxIw==",
+            "content_md5": "5bab79ebd68bf1e947569e8e587f165f",
+            "content_sha1": "5bfabda6b02397fb709a162dc4a350bbcac83b8b",
+            "content_sha256": "eb609f42eaf67b9d418a1fc033c14dd2211494cc79151ba5702680f902594cf8",
+            "content_sha512": "270f9217e542b04f31947803b9bc50da92079f845861681ada6da3ed5953a11bf58a950de1429607b7da816471019e3cd1326f9123b78a3130dc088a4a30b123",
+            "directory_permission": "0777",
+            "file_permission": "0777",
+            "filename": "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_B.service",
+            "id": "5bfabda6b02397fb709a162dc4a350bbcac83b8b",
+            "sensitive_content": null,
+            "source": null
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "sensitive_content"
+              }
+            ]
+          ],
+          "identity_schema_version": 0
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "servicio_b",
+      "provider": "provider[\"registry.terraform.io/hashicorp/null\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "4364075706985955479",
+            "triggers": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "dependencies": [
+            "module.servicio_c.local_file.db_dummy",
+            "module.servicio_c.module.servicio_a.local_file.servicio_dummy",
+            "module.servicio_c.module.servicio_a.null_resource.servicio_a",
+            "module.servicio_c.null_resource.servicio_c"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.servicio_c",
+      "mode": "managed",
+      "type": "local_file",
+      "name": "db_dummy",
+      "provider": "provider[\"registry.terraform.io/hashicorp/local\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "content": "Base de datos creada a las 2025-06-18 23:42:47",
+            "content_base64": null,
+            "content_base64sha256": "PGsLG3utSDEiAETM8Gg32bUigJGPet/DgafvrEuTbBQ=",
+            "content_base64sha512": "6B+yXa9iCoXnl1Ce0S7M/CjEJay9sB3xIQKmBBkgEyqfgPpaow2ddcEb7iRTTUNl/9a5ctiT3Rrry5ogaTq28Q==",
+            "content_md5": "ccc1f9e5caf3656521b4ba227916c38e",
+            "content_sha1": "0d4a2bdaeef2c10700d205577922518e890a5ff3",
+            "content_sha256": "3c6b0b1b7bad4831220044ccf06837d9b52280918f7adfc381a7efac4b936c14",
+            "content_sha512": "e81fb25daf620a85e797509ed12eccfc28c425acbdb01df12102a6041920132a9f80fa5aa30d9d75c11bee24534d4365ffd6b972d893dd1aebcb9a20693ab6f1",
+            "directory_permission": "0777",
+            "file_permission": "0777",
+            "filename": "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/db_dummy.txt",
+            "id": "0d4a2bdaeef2c10700d205577922518e890a5ff3",
+            "sensitive_content": null,
+            "source": null
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "sensitive_content"
+              }
+            ]
+          ],
+          "identity_schema_version": 0
+        }
+      ]
+    },
+    {
+      "module": "module.servicio_c",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "servicio_c",
+      "provider": "provider[\"registry.terraform.io/hashicorp/null\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "4655234923691359330",
+            "triggers": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "dependencies": [
+            "module.servicio_c.module.servicio_a.local_file.servicio_dummy",
+            "module.servicio_c.module.servicio_a.null_resource.servicio_a"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.servicio_c.module.servicio_a",
+      "mode": "managed",
+      "type": "local_file",
+      "name": "servicio_dummy",
+      "provider": "provider[\"registry.terraform.io/hashicorp/local\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "content": "Servicio creado a las 2025-06-18 23:42:47",
+            "content_base64": null,
+            "content_base64sha256": "62CfQur2e51Bih/AM8FN0iEUlMx5FRulcCaA+QJZTPg=",
+            "content_base64sha512": "Jw+SF+VCsE8xlHgDubxQ2pIHn4RYYWga2m2j7VlToRv1ipUN4UKWB7fagWRxAZ480TJvkSO3ijEw3AiKSjCxIw==",
+            "content_md5": "5bab79ebd68bf1e947569e8e587f165f",
+            "content_sha1": "5bfabda6b02397fb709a162dc4a350bbcac83b8b",
+            "content_sha256": "eb609f42eaf67b9d418a1fc033c14dd2211494cc79151ba5702680f902594cf8",
+            "content_sha512": "270f9217e542b04f31947803b9bc50da92079f845861681ada6da3ed5953a11bf58a950de1429607b7da816471019e3cd1326f9123b78a3130dc088a4a30b123",
+            "directory_permission": "0777",
+            "file_permission": "0777",
+            "filename": "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service",
+            "id": "5bfabda6b02397fb709a162dc4a350bbcac83b8b",
+            "sensitive_content": null,
+            "source": null
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "sensitive_content"
+              }
+            ]
+          ],
+          "identity_schema_version": 0
+        }
+      ]
+    },
+    {
+      "module": "module.servicio_c.module.servicio_a",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "servicio_a",
+      "provider": "provider[\"registry.terraform.io/hashicorp/null\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "8290191218549315080",
+            "triggers": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0
+        }
+      ]
+    }
+  ],
+  "check_results": null
+}

--- a/backups/v1_7_0/servicio_c/tfstate_v1.7.0.tfstate
+++ b/backups/v1_7_0/servicio_c/tfstate_v1.7.0.tfstate
@@ -1,0 +1,122 @@
+{
+  "version": 4,
+  "terraform_version": "1.12.1",
+  "serial": 9,
+  "lineage": "bc927bc3-aa48-2a05-a338-fbd74c67f61b",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "local_file",
+      "name": "db_dummy",
+      "provider": "provider[\"registry.terraform.io/hashicorp/local\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "content": "Base de datos creada a las 2025-06-18 23:42:45",
+            "content_base64": null,
+            "content_base64sha256": "crqxgU1wbMturENoEzZqcR4VvwmO+aIudat5dfBl++A=",
+            "content_base64sha512": "3zOAx199bMfRyONUJ/L2deLDkrqKgAxf+dyxj7GGObI6NvQTofH1lhSVeXIqb7rfWv1zXumhNnv3FaTucMFxVQ==",
+            "content_md5": "2c2a9e12a979ac89344fa977b95db16d",
+            "content_sha1": "7453bf338c6135145aeb26a89cc8b5359fc5098b",
+            "content_sha256": "72bab1814d706ccb6eac436813366a711e15bf098ef9a22e75ab7975f065fbe0",
+            "content_sha512": "df3380c75f7d6cc7d1c8e35427f2f675e2c392ba8a800c5ff9dcb18fb18639b23a36f413a1f1f596149579722a6fbadf5afd735ee9a1367bf715a4ee70c17155",
+            "directory_permission": "0777",
+            "file_permission": "0777",
+            "filename": "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/db_dummy.txt",
+            "id": "7453bf338c6135145aeb26a89cc8b5359fc5098b",
+            "sensitive_content": null,
+            "source": null
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "sensitive_content"
+              }
+            ]
+          ],
+          "identity_schema_version": 0
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "servicio_c",
+      "provider": "provider[\"registry.terraform.io/hashicorp/null\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "5189715582138057298",
+            "triggers": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "dependencies": [
+            "module.servicio_a.local_file.servicio_dummy",
+            "module.servicio_a.null_resource.servicio_a"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.servicio_a",
+      "mode": "managed",
+      "type": "local_file",
+      "name": "servicio_dummy",
+      "provider": "provider[\"registry.terraform.io/hashicorp/local\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "content": "Servicio creado a las 2025-06-18 23:42:45",
+            "content_base64": null,
+            "content_base64sha256": "uvIf7hOIGmKnehuh+W4iqxJ4SPTDt8ZHpF7HT032qjs=",
+            "content_base64sha512": "OyCDUT1GAGZJKHTBiRusFwjUoankvON1q4dDbzeaiWhzgDDo7+JVxI5KD4FGkplsxCHKXZXBRbQX8+hqZBRnxg==",
+            "content_md5": "1cc0ab2a2ec34171087e38116c26ce17",
+            "content_sha1": "a38f5d913f0220adee4b3add1bd28554c162c225",
+            "content_sha256": "baf21fee13881a62a77a1ba1f96e22ab127848f4c3b7c647a45ec74f4df6aa3b",
+            "content_sha512": "3b2083513d460066492874c1891bac1708d4a1a9e4bce375ab87436f379a8968738030e8efe255c48e4a0f814692996cc421ca5d95c145b417f3e86a641467c6",
+            "directory_permission": "0777",
+            "file_permission": "0777",
+            "filename": "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service",
+            "id": "a38f5d913f0220adee4b3add1bd28554c162c225",
+            "sensitive_content": null,
+            "source": null
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "sensitive_content"
+              }
+            ]
+          ],
+          "identity_schema_version": 0
+        }
+      ]
+    },
+    {
+      "module": "module.servicio_a",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "servicio_a",
+      "provider": "provider[\"registry.terraform.io/hashicorp/null\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "7594903794493526689",
+            "triggers": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0
+        }
+      ]
+    }
+  ],
+  "check_results": null
+}

--- a/backups/v1_7_0/servicio_d/tfstate_v1.7.0.tfstate
+++ b/backups/v1_7_0/servicio_d/tfstate_v1.7.0.tfstate
@@ -1,0 +1,210 @@
+{
+  "version": 4,
+  "terraform_version": "1.12.1",
+  "serial": 13,
+  "lineage": "0d12cb95-1416-4f46-8107-b28178cd7ae3",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "servicio_d",
+      "provider": "provider[\"registry.terraform.io/hashicorp/null\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "3446376636890549700",
+            "triggers": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "dependencies": [
+            "module.servicio_b.local_file.servicio_dummy",
+            "module.servicio_b.module.servicio_c.local_file.db_dummy",
+            "module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy",
+            "module.servicio_b.module.servicio_c.module.servicio_a.null_resource.servicio_a",
+            "module.servicio_b.module.servicio_c.null_resource.servicio_c",
+            "module.servicio_b.null_resource.servicio_b"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.servicio_b",
+      "mode": "managed",
+      "type": "local_file",
+      "name": "servicio_dummy",
+      "provider": "provider[\"registry.terraform.io/hashicorp/local\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "content": "Servicio creado a las 2025-06-18 23:42:49",
+            "content_base64": null,
+            "content_base64sha256": "s9bBpCZm7dd7RoCc9KKBoNhOdxpLV39OoRriHvqTfj8=",
+            "content_base64sha512": "MqKvYYpdHecx4Q6bXlNoL/heid9pfvFjJolhvBubtVLlxlFvmuPcdiEpTp5zykAruFsNTjKWp86KjGzpLlMtyQ==",
+            "content_md5": "98275962346709efa1fb90cb6dde564c",
+            "content_sha1": "9cb27978bc2cf5bd5cc35f5ef637fda3e9fdd6a2",
+            "content_sha256": "b3d6c1a42666edd77b46809cf4a281a0d84e771a4b577f4ea11ae21efa937e3f",
+            "content_sha512": "32a2af618a5d1de731e10e9b5e53682ff85e89df697ef163268961bc1b9bb552e5c6516f9ae3dc7621294e9e73ca402bb85b0d4e3296a7ce8a8c6ce92e532dc9",
+            "directory_permission": "0777",
+            "file_permission": "0777",
+            "filename": "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_B.service",
+            "id": "9cb27978bc2cf5bd5cc35f5ef637fda3e9fdd6a2",
+            "sensitive_content": null,
+            "source": null
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "sensitive_content"
+              }
+            ]
+          ],
+          "identity_schema_version": 0
+        }
+      ]
+    },
+    {
+      "module": "module.servicio_b",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "servicio_b",
+      "provider": "provider[\"registry.terraform.io/hashicorp/null\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "7760375672855320056",
+            "triggers": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "dependencies": [
+            "module.servicio_b.module.servicio_c.local_file.db_dummy",
+            "module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy",
+            "module.servicio_b.module.servicio_c.module.servicio_a.null_resource.servicio_a",
+            "module.servicio_b.module.servicio_c.null_resource.servicio_c"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.servicio_b.module.servicio_c",
+      "mode": "managed",
+      "type": "local_file",
+      "name": "db_dummy",
+      "provider": "provider[\"registry.terraform.io/hashicorp/local\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "content": "Base de datos creada a las 2025-06-18 23:42:49",
+            "content_base64": null,
+            "content_base64sha256": "7Y+lpGbSdzWKPFZi1hvbNYdhmDMxyEYMyM2mEzMm4kc=",
+            "content_base64sha512": "7vhf2idFcWol9+BLk/LofH543LuNCPD6oD8u9d112Kui3VbIjA0UMGNnXtlJNmnJ/ToEvPbwx4wzbzXMeFVpfA==",
+            "content_md5": "8896bc93716182c02c7ffaa5dbca52bf",
+            "content_sha1": "d811e1a1422bd1bcde4a8740d631a9dbe4a447c4",
+            "content_sha256": "ed8fa5a466d277358a3c5662d61bdb358761983331c8460cc8cda6133326e247",
+            "content_sha512": "eef85fda2745716a25f7e04b93f2e87c7e78dcbb8d08f0faa03f2ef5dd75d8aba2dd56c88c0d143063675ed9493669c9fd3a04bcf6f0c78c336f35cc7855697c",
+            "directory_permission": "0777",
+            "file_permission": "0777",
+            "filename": "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/db_dummy.txt",
+            "id": "d811e1a1422bd1bcde4a8740d631a9dbe4a447c4",
+            "sensitive_content": null,
+            "source": null
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "sensitive_content"
+              }
+            ]
+          ],
+          "identity_schema_version": 0
+        }
+      ]
+    },
+    {
+      "module": "module.servicio_b.module.servicio_c",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "servicio_c",
+      "provider": "provider[\"registry.terraform.io/hashicorp/null\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "4453232201833176036",
+            "triggers": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "dependencies": [
+            "module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy",
+            "module.servicio_b.module.servicio_c.module.servicio_a.null_resource.servicio_a"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.servicio_b.module.servicio_c.module.servicio_a",
+      "mode": "managed",
+      "type": "local_file",
+      "name": "servicio_dummy",
+      "provider": "provider[\"registry.terraform.io/hashicorp/local\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "content": "Servicio creado a las 2025-06-18 23:42:49",
+            "content_base64": null,
+            "content_base64sha256": "s9bBpCZm7dd7RoCc9KKBoNhOdxpLV39OoRriHvqTfj8=",
+            "content_base64sha512": "MqKvYYpdHecx4Q6bXlNoL/heid9pfvFjJolhvBubtVLlxlFvmuPcdiEpTp5zykAruFsNTjKWp86KjGzpLlMtyQ==",
+            "content_md5": "98275962346709efa1fb90cb6dde564c",
+            "content_sha1": "9cb27978bc2cf5bd5cc35f5ef637fda3e9fdd6a2",
+            "content_sha256": "b3d6c1a42666edd77b46809cf4a281a0d84e771a4b577f4ea11ae21efa937e3f",
+            "content_sha512": "32a2af618a5d1de731e10e9b5e53682ff85e89df697ef163268961bc1b9bb552e5c6516f9ae3dc7621294e9e73ca402bb85b0d4e3296a7ce8a8c6ce92e532dc9",
+            "directory_permission": "0777",
+            "file_permission": "0777",
+            "filename": "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service",
+            "id": "9cb27978bc2cf5bd5cc35f5ef637fda3e9fdd6a2",
+            "sensitive_content": null,
+            "source": null
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "sensitive_content"
+              }
+            ]
+          ],
+          "identity_schema_version": 0
+        }
+      ]
+    },
+    {
+      "module": "module.servicio_b.module.servicio_c.module.servicio_a",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "servicio_a",
+      "provider": "provider[\"registry.terraform.io/hashicorp/null\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "2258264413017640814",
+            "triggers": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0
+        }
+      ]
+    }
+  ],
+  "check_results": null
+}

--- a/logs/deploy_20250618-205306.log
+++ b/logs/deploy_20250618-205306.log
@@ -1,0 +1,244 @@
+Initializing the backend...
+Initializing provider plugins...
+- Finding latest version of hashicorp/null...
+- Installing hashicorp/null v3.2.4...
+- Installed hashicorp/null v3.2.4 (signed by HashiCorp)
+Terraform has created a lock file .terraform.lock.hcl to record the provider
+selections it made above. Include this file in your version control repository
+so that Terraform can guarantee to make the same selections by default when
+you run "terraform init" in the future.
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # null_resource.servicio_a will be created
+  + resource "null_resource" "servicio_a" {
+      + id = (known after apply)
+    }
+
+Plan: 1 to add, 0 to change, 0 to destroy.
+null_resource.servicio_a: Creating...
+null_resource.servicio_a: Provisioning with 'local-exec'...
+null_resource.servicio_a (local-exec): Executing: ["/bin/sh" "-c" "/home/dirac/Documents/DS/GitOps-Local/scripts/instala_servicio.sh servicio_dummy_A.service /home/dirac/Documents/DS/GitOps-Local/servicios_simulados"]
+null_resource.servicio_a (local-exec): Instalando servicio_dummy_A.service ...
+null_resource.servicio_a (local-exec): servicio_dummy_A.service se esta instalando en /home/dirac/Documents/DS/GitOps-Local/servicios_simulados
+null_resource.servicio_a (local-exec): Iniciando la instalacion de 'servicio_dummy_A.service ...
+null_resource.servicio_a (local-exec): Realizando configuraciones necesarias...
+null_resource.servicio_a (local-exec): Verificando dependencias
+null_resource.servicio_a (local-exec): Ha finalizado la instalacion exitosamente
+null_resource.servicio_a: Creation complete after 0s [id=8771288233724656698]
+
+Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+Initializing the backend...
+Initializing modules...
+- servicio_a in ../servicio_a
+Initializing provider plugins...
+- Finding latest version of hashicorp/null...
+- Installing hashicorp/null v3.2.4...
+- Installed hashicorp/null v3.2.4 (signed by HashiCorp)
+Terraform has created a lock file .terraform.lock.hcl to record the provider
+selections it made above. Include this file in your version control repository
+so that Terraform can guarantee to make the same selections by default when
+you run "terraform init" in the future.
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # null_resource.servicio_c will be created
+  + resource "null_resource" "servicio_c" {
+      + id = (known after apply)
+    }
+
+  # module.servicio_a.null_resource.servicio_a will be created
+  + resource "null_resource" "servicio_a" {
+      + id = (known after apply)
+    }
+
+Plan: 2 to add, 0 to change, 0 to destroy.
+module.servicio_a.null_resource.servicio_a: Creating...
+module.servicio_a.null_resource.servicio_a: Provisioning with 'local-exec'...
+module.servicio_a.null_resource.servicio_a (local-exec): Executing: ["/bin/sh" "-c" "/home/dirac/Documents/DS/GitOps-Local/scripts/instala_servicio.sh servicio_dummy_A.service /home/dirac/Documents/DS/GitOps-Local/servicios_simulados"]
+module.servicio_a.null_resource.servicio_a (local-exec): Instalando servicio_dummy_A.service ...
+module.servicio_a.null_resource.servicio_a (local-exec): servicio_dummy_A.service se esta instalando en /home/dirac/Documents/DS/GitOps-Local/servicios_simulados
+module.servicio_a.null_resource.servicio_a (local-exec): Iniciando la instalacion de 'servicio_dummy_A.service ...
+module.servicio_a.null_resource.servicio_a (local-exec): El servicio servicio_dummy_A.service ya existe
+module.servicio_a.null_resource.servicio_a: Creation complete after 0s [id=7594903794493526689]
+null_resource.servicio_c: Creating...
+null_resource.servicio_c: Provisioning with 'local-exec'...
+null_resource.servicio_c (local-exec): Executing: ["/bin/sh" "-c" "if [ ! -f \"/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/db_dummy.txt\" ]; then\n  echo \"Instalando servicio de base de datos\"\n  mkdir -p \"/home/dirac/Documents/DS/GitOps-Local/servicios_simulados\"\n  echo \"Base de datos creada el $(date +%Y-%m-%d) a las $(date +%H:%M:%S)\" >> /home/dirac/Documents/DS/GitOps-Local/servicios_simulados/db_dummy.txt\nfi\n"]
+null_resource.servicio_c (local-exec): Instalando servicio de base de datos
+null_resource.servicio_c: Creation complete after 0s [id=5189715582138057298]
+
+Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
+Initializing the backend...
+Initializing modules...
+- servicio_c in ../servicio_c
+- servicio_c.servicio_a in ../servicio_a
+Initializing provider plugins...
+- Finding latest version of hashicorp/null...
+- Installing hashicorp/null v3.2.4...
+- Installed hashicorp/null v3.2.4 (signed by HashiCorp)
+Terraform has created a lock file .terraform.lock.hcl to record the provider
+selections it made above. Include this file in your version control repository
+so that Terraform can guarantee to make the same selections by default when
+you run "terraform init" in the future.
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # null_resource.servicio_b will be created
+  + resource "null_resource" "servicio_b" {
+      + id = (known after apply)
+    }
+
+  # module.servicio_c.null_resource.servicio_c will be created
+  + resource "null_resource" "servicio_c" {
+      + id = (known after apply)
+    }
+
+  # module.servicio_c.module.servicio_a.null_resource.servicio_a will be created
+  + resource "null_resource" "servicio_a" {
+      + id = (known after apply)
+    }
+
+Plan: 3 to add, 0 to change, 0 to destroy.
+module.servicio_c.module.servicio_a.null_resource.servicio_a: Creating...
+module.servicio_c.module.servicio_a.null_resource.servicio_a: Provisioning with 'local-exec'...
+module.servicio_c.module.servicio_a.null_resource.servicio_a (local-exec): Executing: ["/bin/sh" "-c" "/home/dirac/Documents/DS/GitOps-Local/scripts/instala_servicio.sh servicio_dummy_A.service /home/dirac/Documents/DS/GitOps-Local/servicios_simulados"]
+module.servicio_c.module.servicio_a.null_resource.servicio_a (local-exec): Instalando servicio_dummy_A.service ...
+module.servicio_c.module.servicio_a.null_resource.servicio_a (local-exec): servicio_dummy_A.service se esta instalando en /home/dirac/Documents/DS/GitOps-Local/servicios_simulados
+module.servicio_c.module.servicio_a.null_resource.servicio_a (local-exec): Iniciando la instalacion de 'servicio_dummy_A.service ...
+module.servicio_c.module.servicio_a.null_resource.servicio_a (local-exec): El servicio servicio_dummy_A.service ya existe
+module.servicio_c.module.servicio_a.null_resource.servicio_a: Creation complete after 0s [id=8290191218549315080]
+module.servicio_c.null_resource.servicio_c: Creating...
+module.servicio_c.null_resource.servicio_c: Provisioning with 'local-exec'...
+module.servicio_c.null_resource.servicio_c (local-exec): Executing: ["/bin/sh" "-c" "if [ ! -f \"/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/db_dummy.txt\" ]; then\n  echo \"Instalando servicio de base de datos\"\n  mkdir -p \"/home/dirac/Documents/DS/GitOps-Local/servicios_simulados\"\n  echo \"Base de datos creada el $(date +%Y-%m-%d) a las $(date +%H:%M:%S)\" >> /home/dirac/Documents/DS/GitOps-Local/servicios_simulados/db_dummy.txt\nfi\n"]
+module.servicio_c.null_resource.servicio_c: Creation complete after 0s [id=4655234923691359330]
+null_resource.servicio_b: Creating...
+null_resource.servicio_b: Provisioning with 'local-exec'...
+null_resource.servicio_b (local-exec): Executing: ["/bin/sh" "-c" "/home/dirac/Documents/DS/GitOps-Local/scripts/instala_servicio.sh servicio_dummy_B.service /home/dirac/Documents/DS/GitOps-Local/servicios_simulados"]
+null_resource.servicio_b (local-exec): Instalando servicio_dummy_B.service ...
+null_resource.servicio_b (local-exec): servicio_dummy_B.service se esta instalando en /home/dirac/Documents/DS/GitOps-Local/servicios_simulados
+null_resource.servicio_b (local-exec): Iniciando la instalacion de 'servicio_dummy_B.service ...
+null_resource.servicio_b (local-exec): Realizando configuraciones necesarias...
+null_resource.servicio_b (local-exec): Verificando dependencias
+null_resource.servicio_b (local-exec): Ha finalizado la instalacion exitosamente
+null_resource.servicio_b: Creation complete after 0s [id=4364075706985955479]
+
+Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
+Initializing the backend...
+Initializing modules...
+- servicio_b in ../servicio_b
+- servicio_b.servicio_c in ../servicio_c
+- servicio_b.servicio_c.servicio_a in ../servicio_a
+Initializing provider plugins...
+- Finding latest version of hashicorp/null...
+- Installing hashicorp/null v3.2.4...
+- Installed hashicorp/null v3.2.4 (signed by HashiCorp)
+Terraform has created a lock file .terraform.lock.hcl to record the provider
+selections it made above. Include this file in your version control repository
+so that Terraform can guarantee to make the same selections by default when
+you run "terraform init" in the future.
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # null_resource.servicio_d will be created
+  + resource "null_resource" "servicio_d" {
+      + id = (known after apply)
+    }
+
+  # module.servicio_b.null_resource.servicio_b will be created
+  + resource "null_resource" "servicio_b" {
+      + id = (known after apply)
+    }
+
+  # module.servicio_b.module.servicio_c.null_resource.servicio_c will be created
+  + resource "null_resource" "servicio_c" {
+      + id = (known after apply)
+    }
+
+  # module.servicio_b.module.servicio_c.module.servicio_a.null_resource.servicio_a will be created
+  + resource "null_resource" "servicio_a" {
+      + id = (known after apply)
+    }
+
+Plan: 4 to add, 0 to change, 0 to destroy.
+module.servicio_b.module.servicio_c.module.servicio_a.null_resource.servicio_a: Creating...
+module.servicio_b.module.servicio_c.module.servicio_a.null_resource.servicio_a: Provisioning with 'local-exec'...
+module.servicio_b.module.servicio_c.module.servicio_a.null_resource.servicio_a (local-exec): Executing: ["/bin/sh" "-c" "/home/dirac/Documents/DS/GitOps-Local/scripts/instala_servicio.sh servicio_dummy_A.service /home/dirac/Documents/DS/GitOps-Local/servicios_simulados"]
+module.servicio_b.module.servicio_c.module.servicio_a.null_resource.servicio_a (local-exec): Instalando servicio_dummy_A.service ...
+module.servicio_b.module.servicio_c.module.servicio_a.null_resource.servicio_a (local-exec): servicio_dummy_A.service se esta instalando en /home/dirac/Documents/DS/GitOps-Local/servicios_simulados
+module.servicio_b.module.servicio_c.module.servicio_a.null_resource.servicio_a (local-exec): Iniciando la instalacion de 'servicio_dummy_A.service ...
+module.servicio_b.module.servicio_c.module.servicio_a.null_resource.servicio_a (local-exec): El servicio servicio_dummy_A.service ya existe
+module.servicio_b.module.servicio_c.module.servicio_a.null_resource.servicio_a: Creation complete after 0s [id=2258264413017640814]
+module.servicio_b.module.servicio_c.null_resource.servicio_c: Creating...
+module.servicio_b.module.servicio_c.null_resource.servicio_c: Provisioning with 'local-exec'...
+module.servicio_b.module.servicio_c.null_resource.servicio_c (local-exec): Executing: ["/bin/sh" "-c" "if [ ! -f \"/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/db_dummy.txt\" ]; then\n  echo \"Instalando servicio de base de datos\"\n  mkdir -p \"/home/dirac/Documents/DS/GitOps-Local/servicios_simulados\"\n  echo \"Base de datos creada el $(date +%Y-%m-%d) a las $(date +%H:%M:%S)\" >> /home/dirac/Documents/DS/GitOps-Local/servicios_simulados/db_dummy.txt\nfi\n"]
+module.servicio_b.module.servicio_c.null_resource.servicio_c: Creation complete after 0s [id=4453232201833176036]
+module.servicio_b.null_resource.servicio_b: Creating...
+module.servicio_b.null_resource.servicio_b: Provisioning with 'local-exec'...
+module.servicio_b.null_resource.servicio_b (local-exec): Executing: ["/bin/sh" "-c" "/home/dirac/Documents/DS/GitOps-Local/scripts/instala_servicio.sh servicio_dummy_B.service /home/dirac/Documents/DS/GitOps-Local/servicios_simulados"]
+module.servicio_b.null_resource.servicio_b (local-exec): Instalando servicio_dummy_B.service ...
+module.servicio_b.null_resource.servicio_b (local-exec): servicio_dummy_B.service se esta instalando en /home/dirac/Documents/DS/GitOps-Local/servicios_simulados
+module.servicio_b.null_resource.servicio_b (local-exec): Iniciando la instalacion de 'servicio_dummy_B.service ...
+module.servicio_b.null_resource.servicio_b (local-exec): El servicio servicio_dummy_B.service ya existe
+module.servicio_b.null_resource.servicio_b: Creation complete after 0s [id=7760375672855320056]
+null_resource.servicio_d: Creating...
+null_resource.servicio_d: Provisioning with 'local-exec'...
+null_resource.servicio_d (local-exec): Executing: ["/bin/sh" "-c" "nohup python3 /home/dirac/Documents/DS/GitOps-Local/scripts/cola_dummy.py 127.0.0.1 1234 > /tmp/cola_dummy.log 2>&1 &"]
+null_resource.servicio_d: Creation complete after 0s [id=3446376636890549700]
+
+Apply complete! Resources: 4 added, 0 changed, 0 destroyed.

--- a/logs/deploy_20250618-225817.log
+++ b/logs/deploy_20250618-225817.log
@@ -1,0 +1,123 @@
+Initializing the backend...
+Initializing provider plugins...
+- Finding latest version of hashicorp/null...
+- Installing hashicorp/null v3.2.4...
+- Installed hashicorp/null v3.2.4 (signed by HashiCorp)
+Terraform has created a lock file .terraform.lock.hcl to record the provider
+selections it made above. Include this file in your version control repository
+so that Terraform can guarantee to make the same selections by default when
+you run "terraform init" in the future.
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+null_resource.servicio_a: Refreshing state... [id=8771288233724656698]
+
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
+Initializing the backend...
+Initializing modules...
+- servicio_a in ../servicio_a
+Initializing provider plugins...
+- Finding latest version of hashicorp/null...
+- Installing hashicorp/null v3.2.4...
+- Installed hashicorp/null v3.2.4 (signed by HashiCorp)
+Terraform has created a lock file .terraform.lock.hcl to record the provider
+selections it made above. Include this file in your version control repository
+so that Terraform can guarantee to make the same selections by default when
+you run "terraform init" in the future.
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+module.servicio_a.null_resource.servicio_a: Refreshing state... [id=7594903794493526689]
+null_resource.servicio_c: Refreshing state... [id=5189715582138057298]
+
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
+Initializing the backend...
+Initializing modules...
+- servicio_c in ../servicio_c
+- servicio_c.servicio_a in ../servicio_a
+Initializing provider plugins...
+- Finding latest version of hashicorp/null...
+- Installing hashicorp/null v3.2.4...
+- Installed hashicorp/null v3.2.4 (signed by HashiCorp)
+Terraform has created a lock file .terraform.lock.hcl to record the provider
+selections it made above. Include this file in your version control repository
+so that Terraform can guarantee to make the same selections by default when
+you run "terraform init" in the future.
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+module.servicio_c.module.servicio_a.null_resource.servicio_a: Refreshing state... [id=8290191218549315080]
+module.servicio_c.null_resource.servicio_c: Refreshing state... [id=4655234923691359330]
+null_resource.servicio_b: Refreshing state... [id=4364075706985955479]
+
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
+Initializing the backend...
+Initializing modules...
+- servicio_b in ../servicio_b
+- servicio_b.servicio_c in ../servicio_c
+- servicio_b.servicio_c.servicio_a in ../servicio_a
+Initializing provider plugins...
+- Finding latest version of hashicorp/null...
+- Installing hashicorp/null v3.2.4...
+- Installed hashicorp/null v3.2.4 (signed by HashiCorp)
+Terraform has created a lock file .terraform.lock.hcl to record the provider
+selections it made above. Include this file in your version control repository
+so that Terraform can guarantee to make the same selections by default when
+you run "terraform init" in the future.
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+module.servicio_b.module.servicio_c.module.servicio_a.null_resource.servicio_a: Refreshing state... [id=2258264413017640814]
+module.servicio_b.module.servicio_c.null_resource.servicio_c: Refreshing state... [id=4453232201833176036]
+module.servicio_b.null_resource.servicio_b: Refreshing state... [id=7760375672855320056]
+null_resource.servicio_d: Refreshing state... [id=3446376636890549700]
+
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

--- a/logs/deploy_20250618-230134.log
+++ b/logs/deploy_20250618-230134.log
@@ -1,0 +1,97 @@
+Initializing the backend...
+Initializing provider plugins...
+- Reusing previous version of hashicorp/null from the dependency lock file
+- Using previously-installed hashicorp/null v3.2.4
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+null_resource.servicio_a: Refreshing state... [id=8771288233724656698]
+
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
+Initializing the backend...
+Initializing modules...
+Initializing provider plugins...
+- Reusing previous version of hashicorp/null from the dependency lock file
+- Using previously-installed hashicorp/null v3.2.4
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+module.servicio_a.null_resource.servicio_a: Refreshing state... [id=7594903794493526689]
+null_resource.servicio_c: Refreshing state... [id=5189715582138057298]
+
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
+Initializing the backend...
+Initializing modules...
+Initializing provider plugins...
+- Reusing previous version of hashicorp/null from the dependency lock file
+- Using previously-installed hashicorp/null v3.2.4
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+module.servicio_c.module.servicio_a.null_resource.servicio_a: Refreshing state... [id=8290191218549315080]
+module.servicio_c.null_resource.servicio_c: Refreshing state... [id=4655234923691359330]
+null_resource.servicio_b: Refreshing state... [id=4364075706985955479]
+
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
+Initializing the backend...
+Initializing modules...
+Initializing provider plugins...
+- Reusing previous version of hashicorp/null from the dependency lock file
+- Using previously-installed hashicorp/null v3.2.4
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+module.servicio_b.module.servicio_c.module.servicio_a.null_resource.servicio_a: Refreshing state... [id=2258264413017640814]
+module.servicio_b.module.servicio_c.null_resource.servicio_c: Refreshing state... [id=4453232201833176036]
+module.servicio_b.null_resource.servicio_b: Refreshing state... [id=7760375672855320056]
+null_resource.servicio_d: Refreshing state... [id=3446376636890549700]
+
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

--- a/logs/deploy_20250618-231446.log
+++ b/logs/deploy_20250618-231446.log
@@ -1,0 +1,201 @@
+Initializing the backend...
+Initializing provider plugins...
+- Finding latest version of hashicorp/local...
+- Reusing previous version of hashicorp/null from the dependency lock file
+- Installing hashicorp/local v2.5.3...
+- Installed hashicorp/local v2.5.3 (signed by HashiCorp)
+- Using previously-installed hashicorp/null v3.2.4
+Terraform has made some changes to the provider dependency selections recorded
+in the .terraform.lock.hcl file. Review those changes and commit them to your
+version control system if they represent changes you intended to make.
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+null_resource.servicio_a: Refreshing state... [id=8771288233724656698]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service"
+      + id                   = (known after apply)
+    }
+
+Plan: 1 to add, 0 to change, 0 to destroy.
+local_file.servicio_dummy: Creating...
+local_file.servicio_dummy: Creation complete after 0s [id=d1e1a076215e1df09a91217807cdca0a91f692dc]
+
+Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+Initializing the backend...
+Initializing modules...
+Initializing provider plugins...
+- Reusing previous version of hashicorp/null from the dependency lock file
+- Finding latest version of hashicorp/local...
+- Installing hashicorp/local v2.5.3...
+- Installed hashicorp/local v2.5.3 (signed by HashiCorp)
+- Using previously-installed hashicorp/null v3.2.4
+Terraform has made some changes to the provider dependency selections recorded
+in the .terraform.lock.hcl file. Review those changes and commit them to your
+version control system if they represent changes you intended to make.
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+module.servicio_a.null_resource.servicio_a: Refreshing state... [id=7594903794493526689]
+null_resource.servicio_c: Refreshing state... [id=5189715582138057298]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # module.servicio_a.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service"
+      + id                   = (known after apply)
+    }
+
+Plan: 1 to add, 0 to change, 0 to destroy.
+module.servicio_a.local_file.servicio_dummy: Creating...
+module.servicio_a.local_file.servicio_dummy: Creation complete after 0s [id=defdafa6658d1913acd66d1eb59c03c85e618a75]
+
+Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+Initializing the backend...
+Initializing modules...
+Initializing provider plugins...
+- Reusing previous version of hashicorp/null from the dependency lock file
+- Finding latest version of hashicorp/local...
+- Using previously-installed hashicorp/null v3.2.4
+- Installing hashicorp/local v2.5.3...
+- Installed hashicorp/local v2.5.3 (signed by HashiCorp)
+Terraform has made some changes to the provider dependency selections recorded
+in the .terraform.lock.hcl file. Review those changes and commit them to your
+version control system if they represent changes you intended to make.
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+module.servicio_c.module.servicio_a.null_resource.servicio_a: Refreshing state... [id=8290191218549315080]
+module.servicio_c.null_resource.servicio_c: Refreshing state... [id=4655234923691359330]
+null_resource.servicio_b: Refreshing state... [id=4364075706985955479]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # module.servicio_c.module.servicio_a.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service"
+      + id                   = (known after apply)
+    }
+
+Plan: 1 to add, 0 to change, 0 to destroy.
+module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creating...
+module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creation complete after 0s [id=867e71f3b1042c7e358695127bdd3278cd21c544]
+
+Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+Initializing the backend...
+Initializing modules...
+Initializing provider plugins...
+- Finding latest version of hashicorp/local...
+- Reusing previous version of hashicorp/null from the dependency lock file
+- Installing hashicorp/local v2.5.3...
+- Installed hashicorp/local v2.5.3 (signed by HashiCorp)
+- Using previously-installed hashicorp/null v3.2.4
+Terraform has made some changes to the provider dependency selections recorded
+in the .terraform.lock.hcl file. Review those changes and commit them to your
+version control system if they represent changes you intended to make.
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+module.servicio_b.module.servicio_c.module.servicio_a.null_resource.servicio_a: Refreshing state... [id=2258264413017640814]
+module.servicio_b.module.servicio_c.null_resource.servicio_c: Refreshing state... [id=4453232201833176036]
+module.servicio_b.null_resource.servicio_b: Refreshing state... [id=7760375672855320056]
+null_resource.servicio_d: Refreshing state... [id=3446376636890549700]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service"
+      + id                   = (known after apply)
+    }
+
+Plan: 1 to add, 0 to change, 0 to destroy.
+module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creating...
+module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creation complete after 0s [id=5ac14e70cb1316db38cf58d02efbd014fb986e90]
+
+Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

--- a/logs/deploy_20250618-231811.log
+++ b/logs/deploy_20250618-231811.log
@@ -1,0 +1,223 @@
+Initializing the backend...
+Initializing provider plugins...
+- Reusing previous version of hashicorp/local from the dependency lock file
+- Reusing previous version of hashicorp/null from the dependency lock file
+- Using previously-installed hashicorp/local v2.5.3
+- Using previously-installed hashicorp/null v3.2.4
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+null_resource.servicio_a: Refreshing state... [id=8771288233724656698]
+local_file.servicio_dummy: Refreshing state... [id=d1e1a076215e1df09a91217807cdca0a91f692dc]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service"
+      + id                   = (known after apply)
+    }
+
+Plan: 1 to add, 0 to change, 0 to destroy.
+local_file.servicio_dummy: Creating...
+local_file.servicio_dummy: Creation complete after 0s [id=5a2809ee0f769dd3492bdd53ab8e0d1a26dd6059]
+
+Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+Initializing the backend...
+Initializing modules...
+Initializing provider plugins...
+- Reusing previous version of hashicorp/null from the dependency lock file
+- Reusing previous version of hashicorp/local from the dependency lock file
+- Using previously-installed hashicorp/null v3.2.4
+- Using previously-installed hashicorp/local v2.5.3
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+module.servicio_a.null_resource.servicio_a: Refreshing state... [id=7594903794493526689]
+module.servicio_a.local_file.servicio_dummy: Refreshing state... [id=defdafa6658d1913acd66d1eb59c03c85e618a75]
+null_resource.servicio_c: Refreshing state... [id=5189715582138057298]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # module.servicio_a.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service"
+      + id                   = (known after apply)
+    }
+
+Plan: 1 to add, 0 to change, 0 to destroy.
+module.servicio_a.local_file.servicio_dummy: Creating...
+module.servicio_a.local_file.servicio_dummy: Creation complete after 0s [id=b34fb4ce6e7317767ab74ae6dc2d0ea8e1afc2f5]
+
+Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+Initializing the backend...
+Initializing modules...
+Initializing provider plugins...
+- Reusing previous version of hashicorp/local from the dependency lock file
+- Reusing previous version of hashicorp/null from the dependency lock file
+- Using previously-installed hashicorp/local v2.5.3
+- Using previously-installed hashicorp/null v3.2.4
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+module.servicio_c.module.servicio_a.local_file.servicio_dummy: Refreshing state... [id=867e71f3b1042c7e358695127bdd3278cd21c544]
+module.servicio_c.module.servicio_a.null_resource.servicio_a: Refreshing state... [id=8290191218549315080]
+module.servicio_c.null_resource.servicio_c: Refreshing state... [id=4655234923691359330]
+null_resource.servicio_b: Refreshing state... [id=4364075706985955479]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_B.service"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_c.module.servicio_a.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service"
+      + id                   = (known after apply)
+    }
+
+Plan: 2 to add, 0 to change, 0 to destroy.
+local_file.servicio_dummy: Creating...
+module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creating...
+local_file.servicio_dummy: Creation complete after 0s [id=84eb6cf2bcf5123f3e166f379e782a5666022171]
+module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creation complete after 0s [id=84eb6cf2bcf5123f3e166f379e782a5666022171]
+
+Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
+Initializing the backend...
+Initializing modules...
+Initializing provider plugins...
+- Reusing previous version of hashicorp/local from the dependency lock file
+- Reusing previous version of hashicorp/null from the dependency lock file
+- Using previously-installed hashicorp/null v3.2.4
+- Using previously-installed hashicorp/local v2.5.3
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy: Refreshing state... [id=5ac14e70cb1316db38cf58d02efbd014fb986e90]
+module.servicio_b.module.servicio_c.module.servicio_a.null_resource.servicio_a: Refreshing state... [id=2258264413017640814]
+module.servicio_b.module.servicio_c.null_resource.servicio_c: Refreshing state... [id=4453232201833176036]
+module.servicio_b.null_resource.servicio_b: Refreshing state... [id=7760375672855320056]
+null_resource.servicio_d: Refreshing state... [id=3446376636890549700]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # module.servicio_b.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_B.service"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service"
+      + id                   = (known after apply)
+    }
+
+Plan: 2 to add, 0 to change, 0 to destroy.
+module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creating...
+module.servicio_b.local_file.servicio_dummy: Creating...
+module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creation complete after 0s [id=f4ba9a32d9aa3360adad44673b4d563f70b63f69]
+module.servicio_b.local_file.servicio_dummy: Creation complete after 0s [id=f4ba9a32d9aa3360adad44673b4d563f70b63f69]
+
+Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

--- a/logs/deploy_20250618-231953.log
+++ b/logs/deploy_20250618-231953.log
@@ -1,0 +1,276 @@
+Initializing the backend...
+Initializing provider plugins...
+- Reusing previous version of hashicorp/null from the dependency lock file
+- Reusing previous version of hashicorp/local from the dependency lock file
+- Using previously-installed hashicorp/null v3.2.4
+- Using previously-installed hashicorp/local v2.5.3
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+null_resource.servicio_a: Refreshing state... [id=8771288233724656698]
+local_file.servicio_dummy: Refreshing state... [id=5a2809ee0f769dd3492bdd53ab8e0d1a26dd6059]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service"
+      + id                   = (known after apply)
+    }
+
+Plan: 1 to add, 0 to change, 0 to destroy.
+local_file.servicio_dummy: Creating...
+local_file.servicio_dummy: Creation complete after 0s [id=a6616c3274ca703fe123cc188696e53b4b1c2bfb]
+
+Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+Initializing the backend...
+Initializing modules...
+Initializing provider plugins...
+- Reusing previous version of hashicorp/local from the dependency lock file
+- Reusing previous version of hashicorp/null from the dependency lock file
+- Using previously-installed hashicorp/local v2.5.3
+- Using previously-installed hashicorp/null v3.2.4
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+module.servicio_a.local_file.servicio_dummy: Refreshing state... [id=b34fb4ce6e7317767ab74ae6dc2d0ea8e1afc2f5]
+module.servicio_a.null_resource.servicio_a: Refreshing state... [id=7594903794493526689]
+null_resource.servicio_c: Refreshing state... [id=5189715582138057298]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/db_dummy.txt"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_a.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service"
+      + id                   = (known after apply)
+    }
+
+Plan: 2 to add, 0 to change, 0 to destroy.
+local_file.servicio_dummy: Creating...
+module.servicio_a.local_file.servicio_dummy: Creating...
+module.servicio_a.local_file.servicio_dummy: Creation complete after 0s [id=fedce6e549caf44ce5f731dd0ec80516d0e893e2]
+local_file.servicio_dummy: Creation complete after 0s [id=c785254a83a8b8c067a0fca8a992ddb8f3449dbe]
+
+Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
+Initializing the backend...
+Initializing modules...
+Initializing provider plugins...
+- Reusing previous version of hashicorp/null from the dependency lock file
+- Reusing previous version of hashicorp/local from the dependency lock file
+- Using previously-installed hashicorp/null v3.2.4
+- Using previously-installed hashicorp/local v2.5.3
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+module.servicio_c.module.servicio_a.null_resource.servicio_a: Refreshing state... [id=8290191218549315080]
+local_file.servicio_dummy: Refreshing state... [id=84eb6cf2bcf5123f3e166f379e782a5666022171]
+module.servicio_c.module.servicio_a.local_file.servicio_dummy: Refreshing state... [id=84eb6cf2bcf5123f3e166f379e782a5666022171]
+module.servicio_c.null_resource.servicio_c: Refreshing state... [id=4655234923691359330]
+null_resource.servicio_b: Refreshing state... [id=4364075706985955479]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_B.service"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_c.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/db_dummy.txt"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_c.module.servicio_a.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service"
+      + id                   = (known after apply)
+    }
+
+Plan: 3 to add, 0 to change, 0 to destroy.
+module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creating...
+local_file.servicio_dummy: Creating...
+module.servicio_c.local_file.servicio_dummy: Creating...
+module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creation complete after 0s [id=39ce5419f675e6a7af9b590461242fee8ad1395e]
+local_file.servicio_dummy: Creation complete after 0s [id=39ce5419f675e6a7af9b590461242fee8ad1395e]
+module.servicio_c.local_file.servicio_dummy: Creation complete after 0s [id=59b8c196199c2dc3190e05b6ced1650faceb5b05]
+
+Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
+Initializing the backend...
+Initializing modules...
+Initializing provider plugins...
+- Reusing previous version of hashicorp/local from the dependency lock file
+- Reusing previous version of hashicorp/null from the dependency lock file
+- Using previously-installed hashicorp/local v2.5.3
+- Using previously-installed hashicorp/null v3.2.4
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+module.servicio_b.module.servicio_c.module.servicio_a.null_resource.servicio_a: Refreshing state... [id=2258264413017640814]
+module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy: Refreshing state... [id=f4ba9a32d9aa3360adad44673b4d563f70b63f69]
+module.servicio_b.local_file.servicio_dummy: Refreshing state... [id=f4ba9a32d9aa3360adad44673b4d563f70b63f69]
+module.servicio_b.module.servicio_c.null_resource.servicio_c: Refreshing state... [id=4453232201833176036]
+module.servicio_b.null_resource.servicio_b: Refreshing state... [id=7760375672855320056]
+null_resource.servicio_d: Refreshing state... [id=3446376636890549700]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # module.servicio_b.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_B.service"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_b.module.servicio_c.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/db_dummy.txt"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service"
+      + id                   = (known after apply)
+    }
+
+Plan: 3 to add, 0 to change, 0 to destroy.
+module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creating...
+module.servicio_b.module.servicio_c.local_file.servicio_dummy: Creating...
+module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creation complete after 0s [id=c4893f27f903383fca43ca5b1d02824580c993be]
+module.servicio_b.local_file.servicio_dummy: Creating...
+module.servicio_b.module.servicio_c.local_file.servicio_dummy: Creation complete after 0s [id=5ec6dff1671edbe6aa6360501ea8ecfd57b5adeb]
+module.servicio_b.local_file.servicio_dummy: Creation complete after 0s [id=c4893f27f903383fca43ca5b1d02824580c993be]
+
+Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

--- a/logs/deploy_20250618-232120.log
+++ b/logs/deploy_20250618-232120.log
@@ -1,0 +1,279 @@
+Initializing the backend...
+Initializing provider plugins...
+- Reusing previous version of hashicorp/local from the dependency lock file
+- Reusing previous version of hashicorp/null from the dependency lock file
+- Using previously-installed hashicorp/local v2.5.3
+- Using previously-installed hashicorp/null v3.2.4
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+null_resource.servicio_a: Refreshing state... [id=8771288233724656698]
+local_file.servicio_dummy: Refreshing state... [id=a6616c3274ca703fe123cc188696e53b4b1c2bfb]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service"
+      + id                   = (known after apply)
+    }
+
+Plan: 1 to add, 0 to change, 0 to destroy.
+local_file.servicio_dummy: Creating...
+local_file.servicio_dummy: Creation complete after 0s [id=4fcecc9511d710e797d677a196530cfa335713a6]
+
+Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+Initializing the backend...
+Initializing modules...
+Initializing provider plugins...
+- Reusing previous version of hashicorp/null from the dependency lock file
+- Reusing previous version of hashicorp/local from the dependency lock file
+- Using previously-installed hashicorp/null v3.2.4
+- Using previously-installed hashicorp/local v2.5.3
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+module.servicio_a.null_resource.servicio_a: Refreshing state... [id=7594903794493526689]
+local_file.servicio_dummy: Refreshing state... [id=c785254a83a8b8c067a0fca8a992ddb8f3449dbe]
+module.servicio_a.local_file.servicio_dummy: Refreshing state... [id=fedce6e549caf44ce5f731dd0ec80516d0e893e2]
+null_resource.servicio_c: Refreshing state... [id=5189715582138057298]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/db_dummy.txt"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_a.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service"
+      + id                   = (known after apply)
+    }
+
+Plan: 2 to add, 0 to change, 0 to destroy.
+module.servicio_a.local_file.servicio_dummy: Creating...
+local_file.servicio_dummy: Creating...
+module.servicio_a.local_file.servicio_dummy: Creation complete after 0s [id=474b27a5ed1e58d587b1f343991a6c1fc54c2695]
+local_file.servicio_dummy: Creation complete after 0s [id=f31b7d4fa16b185ea3d0ab09d1d9e0ad79ae5e75]
+
+Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
+Initializing the backend...
+Initializing modules...
+Initializing provider plugins...
+- Reusing previous version of hashicorp/null from the dependency lock file
+- Reusing previous version of hashicorp/local from the dependency lock file
+- Using previously-installed hashicorp/local v2.5.3
+- Using previously-installed hashicorp/null v3.2.4
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+module.servicio_c.local_file.servicio_dummy: Refreshing state... [id=59b8c196199c2dc3190e05b6ced1650faceb5b05]
+local_file.servicio_dummy: Refreshing state... [id=39ce5419f675e6a7af9b590461242fee8ad1395e]
+module.servicio_c.module.servicio_a.local_file.servicio_dummy: Refreshing state... [id=39ce5419f675e6a7af9b590461242fee8ad1395e]
+module.servicio_c.module.servicio_a.null_resource.servicio_a: Refreshing state... [id=8290191218549315080]
+module.servicio_c.null_resource.servicio_c: Refreshing state... [id=4655234923691359330]
+null_resource.servicio_b: Refreshing state... [id=4364075706985955479]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_B.service"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_c.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/db_dummy.txt"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_c.module.servicio_a.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service"
+      + id                   = (known after apply)
+    }
+
+Plan: 3 to add, 0 to change, 0 to destroy.
+module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creating...
+local_file.servicio_dummy: Creating...
+module.servicio_c.local_file.servicio_dummy: Creating...
+local_file.servicio_dummy: Creation complete after 0s [id=b9a3f79820f4a55ffb2e52cfc96a9eff2d29c998]
+module.servicio_c.local_file.servicio_dummy: Creation complete after 0s [id=23b5f5b41299b4c46a5736620c3e251574853fea]
+module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creation complete after 0s [id=b9a3f79820f4a55ffb2e52cfc96a9eff2d29c998]
+
+Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
+Initializing the backend...
+Initializing modules...
+Initializing provider plugins...
+- Reusing previous version of hashicorp/local from the dependency lock file
+- Reusing previous version of hashicorp/null from the dependency lock file
+- Using previously-installed hashicorp/local v2.5.3
+- Using previously-installed hashicorp/null v3.2.4
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+module.servicio_b.local_file.servicio_dummy: Refreshing state... [id=c4893f27f903383fca43ca5b1d02824580c993be]
+module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy: Refreshing state... [id=c4893f27f903383fca43ca5b1d02824580c993be]
+module.servicio_b.module.servicio_c.module.servicio_a.null_resource.servicio_a: Refreshing state... [id=2258264413017640814]
+module.servicio_b.module.servicio_c.local_file.servicio_dummy: Refreshing state... [id=5ec6dff1671edbe6aa6360501ea8ecfd57b5adeb]
+module.servicio_b.module.servicio_c.null_resource.servicio_c: Refreshing state... [id=4453232201833176036]
+module.servicio_b.null_resource.servicio_b: Refreshing state... [id=7760375672855320056]
+null_resource.servicio_d: Refreshing state... [id=3446376636890549700]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # module.servicio_b.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_B.service"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_b.module.servicio_c.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/db_dummy.txt"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service"
+      + id                   = (known after apply)
+    }
+
+Plan: 3 to add, 0 to change, 0 to destroy.
+module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creating...
+module.servicio_b.local_file.servicio_dummy: Creating...
+module.servicio_b.local_file.servicio_dummy: Creation complete after 0s [id=8b0d2269ba565ab5531c9cb02ecefd5ef18d3f7a]
+module.servicio_b.module.servicio_c.local_file.servicio_dummy: Creating...
+module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creation complete after 0s [id=8b0d2269ba565ab5531c9cb02ecefd5ef18d3f7a]
+module.servicio_b.module.servicio_c.local_file.servicio_dummy: Creation complete after 0s [id=710043c7d827fb5794bd2998494cd7d04aac15aa]
+
+Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

--- a/logs/deploy_20250618-232306.log
+++ b/logs/deploy_20250618-232306.log
@@ -1,0 +1,279 @@
+Initializing the backend...
+Initializing provider plugins...
+- Reusing previous version of hashicorp/local from the dependency lock file
+- Reusing previous version of hashicorp/null from the dependency lock file
+- Using previously-installed hashicorp/local v2.5.3
+- Using previously-installed hashicorp/null v3.2.4
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+null_resource.servicio_a: Refreshing state... [id=8771288233724656698]
+local_file.servicio_dummy: Refreshing state... [id=4fcecc9511d710e797d677a196530cfa335713a6]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = "Servicio creado a las $(timestamp() +%Y-%m-%d %H-%M-%S)"
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service"
+      + id                   = (known after apply)
+    }
+
+Plan: 1 to add, 0 to change, 0 to destroy.
+local_file.servicio_dummy: Creating...
+local_file.servicio_dummy: Creation complete after 0s [id=da3f885de47a586c9ea9bf1f9ba1df0261357eab]
+
+Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+Initializing the backend...
+Initializing modules...
+Initializing provider plugins...
+- Reusing previous version of hashicorp/local from the dependency lock file
+- Reusing previous version of hashicorp/null from the dependency lock file
+- Using previously-installed hashicorp/local v2.5.3
+- Using previously-installed hashicorp/null v3.2.4
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+module.servicio_a.null_resource.servicio_a: Refreshing state... [id=7594903794493526689]
+module.servicio_a.local_file.servicio_dummy: Refreshing state... [id=474b27a5ed1e58d587b1f343991a6c1fc54c2695]
+local_file.servicio_dummy: Refreshing state... [id=f31b7d4fa16b185ea3d0ab09d1d9e0ad79ae5e75]
+null_resource.servicio_c: Refreshing state... [id=5189715582138057298]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/db_dummy.txt"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_a.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = "Servicio creado a las $(timestamp() +%Y-%m-%d %H-%M-%S)"
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service"
+      + id                   = (known after apply)
+    }
+
+Plan: 2 to add, 0 to change, 0 to destroy.
+module.servicio_a.local_file.servicio_dummy: Creating...
+local_file.servicio_dummy: Creating...
+local_file.servicio_dummy: Creation complete after 0s [id=a17e0993e356d2b76197601d78d75d0067b98b37]
+module.servicio_a.local_file.servicio_dummy: Creation complete after 0s [id=da3f885de47a586c9ea9bf1f9ba1df0261357eab]
+
+Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
+Initializing the backend...
+Initializing modules...
+Initializing provider plugins...
+- Reusing previous version of hashicorp/local from the dependency lock file
+- Reusing previous version of hashicorp/null from the dependency lock file
+- Using previously-installed hashicorp/local v2.5.3
+- Using previously-installed hashicorp/null v3.2.4
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+module.servicio_c.module.servicio_a.null_resource.servicio_a: Refreshing state... [id=8290191218549315080]
+local_file.servicio_dummy: Refreshing state... [id=b9a3f79820f4a55ffb2e52cfc96a9eff2d29c998]
+module.servicio_c.local_file.servicio_dummy: Refreshing state... [id=23b5f5b41299b4c46a5736620c3e251574853fea]
+module.servicio_c.module.servicio_a.local_file.servicio_dummy: Refreshing state... [id=b9a3f79820f4a55ffb2e52cfc96a9eff2d29c998]
+module.servicio_c.null_resource.servicio_c: Refreshing state... [id=4655234923691359330]
+null_resource.servicio_b: Refreshing state... [id=4364075706985955479]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_B.service"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_c.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/db_dummy.txt"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_c.module.servicio_a.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = "Servicio creado a las $(timestamp() +%Y-%m-%d %H-%M-%S)"
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service"
+      + id                   = (known after apply)
+    }
+
+Plan: 3 to add, 0 to change, 0 to destroy.
+module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creating...
+module.servicio_c.local_file.servicio_dummy: Creating...
+local_file.servicio_dummy: Creating...
+module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creation complete after 0s [id=da3f885de47a586c9ea9bf1f9ba1df0261357eab]
+local_file.servicio_dummy: Creation complete after 0s [id=b5468df64cf9be40202fa32368293552ef28f97b]
+module.servicio_c.local_file.servicio_dummy: Creation complete after 0s [id=bf04024f440b1b679dc364602832068bb0686b6c]
+
+Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
+Initializing the backend...
+Initializing modules...
+Initializing provider plugins...
+- Reusing previous version of hashicorp/null from the dependency lock file
+- Reusing previous version of hashicorp/local from the dependency lock file
+- Using previously-installed hashicorp/null v3.2.4
+- Using previously-installed hashicorp/local v2.5.3
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+module.servicio_b.module.servicio_c.module.servicio_a.null_resource.servicio_a: Refreshing state... [id=2258264413017640814]
+module.servicio_b.local_file.servicio_dummy: Refreshing state... [id=8b0d2269ba565ab5531c9cb02ecefd5ef18d3f7a]
+module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy: Refreshing state... [id=8b0d2269ba565ab5531c9cb02ecefd5ef18d3f7a]
+module.servicio_b.module.servicio_c.local_file.servicio_dummy: Refreshing state... [id=710043c7d827fb5794bd2998494cd7d04aac15aa]
+module.servicio_b.module.servicio_c.null_resource.servicio_c: Refreshing state... [id=4453232201833176036]
+module.servicio_b.null_resource.servicio_b: Refreshing state... [id=7760375672855320056]
+null_resource.servicio_d: Refreshing state... [id=3446376636890549700]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # module.servicio_b.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_B.service"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_b.module.servicio_c.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/db_dummy.txt"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = "Servicio creado a las $(timestamp() +%Y-%m-%d %H-%M-%S)"
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service"
+      + id                   = (known after apply)
+    }
+
+Plan: 3 to add, 0 to change, 0 to destroy.
+module.servicio_b.local_file.servicio_dummy: Creating...
+module.servicio_b.module.servicio_c.local_file.servicio_dummy: Creating...
+module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creating...
+module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creation complete after 0s [id=da3f885de47a586c9ea9bf1f9ba1df0261357eab]
+module.servicio_b.local_file.servicio_dummy: Creation complete after 0s [id=a2f02dbff22e22c97bbee0458aa3015732653556]
+module.servicio_b.module.servicio_c.local_file.servicio_dummy: Creation complete after 0s [id=e481e1feb51527491d96b9356260e5d30127af30]
+
+Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

--- a/logs/deploy_20250618-232417.log
+++ b/logs/deploy_20250618-232417.log
@@ -1,0 +1,279 @@
+Initializing the backend...
+Initializing provider plugins...
+- Reusing previous version of hashicorp/local from the dependency lock file
+- Reusing previous version of hashicorp/null from the dependency lock file
+- Using previously-installed hashicorp/local v2.5.3
+- Using previously-installed hashicorp/null v3.2.4
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+null_resource.servicio_a: Refreshing state... [id=8771288233724656698]
+local_file.servicio_dummy: Refreshing state... [id=da3f885de47a586c9ea9bf1f9ba1df0261357eab]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+-/+ destroy and then create replacement
+
+Terraform will perform the following actions:
+
+  # local_file.servicio_dummy must be replaced
+-/+ resource "local_file" "servicio_dummy" {
+      ~ content              = "Servicio creado a las $(timestamp() +%Y-%m-%d %H-%M-%S)" -> (known after apply) # forces replacement
+      ~ content_base64sha256 = "0OeLFZ2ygFfLtOQGOKYa7K01ChwN4g/bEy3twv/yDXg=" -> (known after apply)
+      ~ content_base64sha512 = "uFrqQ6LK2f+Z5BHUp6Y5/Rf+FG+jH+aUIBkBCwI6x4R/1iiSYEU116HB7SyliP3uaSc549phPHSYfVl/p+3s+g==" -> (known after apply)
+      ~ content_md5          = "539f3ac92d177db42bd010800f40259b" -> (known after apply)
+      ~ content_sha1         = "da3f885de47a586c9ea9bf1f9ba1df0261357eab" -> (known after apply)
+      ~ content_sha256       = "d0e78b159db28057cbb4e40638a61aecad350a1c0de20fdb132dedc2fff20d78" -> (known after apply)
+      ~ content_sha512       = "b85aea43a2cad9ff99e411d4a7a639fd17fe146fa31fe6942019010b023ac7847fd62892604535d7a1c1ed2ca588fdee692739e3da613c74987d597fa7edecfa" -> (known after apply)
+      ~ id                   = "da3f885de47a586c9ea9bf1f9ba1df0261357eab" -> (known after apply)
+        # (3 unchanged attributes hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+local_file.servicio_dummy: Destroying... [id=da3f885de47a586c9ea9bf1f9ba1df0261357eab]
+local_file.servicio_dummy: Destruction complete after 0s
+local_file.servicio_dummy: Creating...
+local_file.servicio_dummy: Creation complete after 0s [id=c594e57e91da438c01aa19f3ce928b4c17b3ddc1]
+
+Apply complete! Resources: 1 added, 0 changed, 1 destroyed.
+Initializing the backend...
+Initializing modules...
+Initializing provider plugins...
+- Reusing previous version of hashicorp/null from the dependency lock file
+- Reusing previous version of hashicorp/local from the dependency lock file
+- Using previously-installed hashicorp/null v3.2.4
+- Using previously-installed hashicorp/local v2.5.3
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+module.servicio_a.null_resource.servicio_a: Refreshing state... [id=7594903794493526689]
+local_file.servicio_dummy: Refreshing state... [id=a17e0993e356d2b76197601d78d75d0067b98b37]
+module.servicio_a.local_file.servicio_dummy: Refreshing state... [id=da3f885de47a586c9ea9bf1f9ba1df0261357eab]
+null_resource.servicio_c: Refreshing state... [id=5189715582138057298]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/db_dummy.txt"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_a.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service"
+      + id                   = (known after apply)
+    }
+
+Plan: 2 to add, 0 to change, 0 to destroy.
+local_file.servicio_dummy: Creating...
+module.servicio_a.local_file.servicio_dummy: Creating...
+module.servicio_a.local_file.servicio_dummy: Creation complete after 0s [id=2ef91e06f3f28beee76efc8751f5e498020b3ac3]
+local_file.servicio_dummy: Creation complete after 0s [id=b9d03f612ad8800b094405fe2f297c4d9ca46040]
+
+Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
+Initializing the backend...
+Initializing modules...
+Initializing provider plugins...
+- Reusing previous version of hashicorp/local from the dependency lock file
+- Reusing previous version of hashicorp/null from the dependency lock file
+- Using previously-installed hashicorp/local v2.5.3
+- Using previously-installed hashicorp/null v3.2.4
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+module.servicio_c.local_file.servicio_dummy: Refreshing state... [id=bf04024f440b1b679dc364602832068bb0686b6c]
+local_file.servicio_dummy: Refreshing state... [id=b5468df64cf9be40202fa32368293552ef28f97b]
+module.servicio_c.module.servicio_a.local_file.servicio_dummy: Refreshing state... [id=da3f885de47a586c9ea9bf1f9ba1df0261357eab]
+module.servicio_c.module.servicio_a.null_resource.servicio_a: Refreshing state... [id=8290191218549315080]
+module.servicio_c.null_resource.servicio_c: Refreshing state... [id=4655234923691359330]
+null_resource.servicio_b: Refreshing state... [id=4364075706985955479]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_B.service"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_c.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/db_dummy.txt"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_c.module.servicio_a.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service"
+      + id                   = (known after apply)
+    }
+
+Plan: 3 to add, 0 to change, 0 to destroy.
+module.servicio_c.local_file.servicio_dummy: Creating...
+local_file.servicio_dummy: Creating...
+module.servicio_c.local_file.servicio_dummy: Creation complete after 0s [id=6c472d9c6a0a73e1a61f0cd958fa180c778e54d8]
+module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creating...
+local_file.servicio_dummy: Creation complete after 0s [id=6e8209badbb73dd361fabbe1f675dca58934c9ec]
+module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creation complete after 0s [id=cb9a206441c6b878e6123dd02cf37479eea0432a]
+
+Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
+Initializing the backend...
+Initializing modules...
+Initializing provider plugins...
+- Reusing previous version of hashicorp/null from the dependency lock file
+- Reusing previous version of hashicorp/local from the dependency lock file
+- Using previously-installed hashicorp/null v3.2.4
+- Using previously-installed hashicorp/local v2.5.3
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy: Refreshing state... [id=da3f885de47a586c9ea9bf1f9ba1df0261357eab]
+module.servicio_b.local_file.servicio_dummy: Refreshing state... [id=a2f02dbff22e22c97bbee0458aa3015732653556]
+module.servicio_b.module.servicio_c.module.servicio_a.null_resource.servicio_a: Refreshing state... [id=2258264413017640814]
+module.servicio_b.module.servicio_c.local_file.servicio_dummy: Refreshing state... [id=e481e1feb51527491d96b9356260e5d30127af30]
+module.servicio_b.module.servicio_c.null_resource.servicio_c: Refreshing state... [id=4453232201833176036]
+module.servicio_b.null_resource.servicio_b: Refreshing state... [id=7760375672855320056]
+null_resource.servicio_d: Refreshing state... [id=3446376636890549700]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # module.servicio_b.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_B.service"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_b.module.servicio_c.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/db_dummy.txt"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service"
+      + id                   = (known after apply)
+    }
+
+Plan: 3 to add, 0 to change, 0 to destroy.
+module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creating...
+module.servicio_b.local_file.servicio_dummy: Creating...
+module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creation complete after 0s [id=1a75210eacd37ea03484efda4634fe9a8bb7aab4]
+module.servicio_b.module.servicio_c.local_file.servicio_dummy: Creating...
+module.servicio_b.local_file.servicio_dummy: Creation complete after 0s [id=a16b1d5415f235466844d1bc5700b1a93a8d1e72]
+module.servicio_b.module.servicio_c.local_file.servicio_dummy: Creation complete after 0s [id=bff4c2be648ef590d16077f3cef4d7d57b01df58]
+
+Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

--- a/logs/deploy_20250618-232501.log
+++ b/logs/deploy_20250618-232501.log
@@ -1,0 +1,279 @@
+Initializing the backend...
+Initializing provider plugins...
+- Reusing previous version of hashicorp/local from the dependency lock file
+- Reusing previous version of hashicorp/null from the dependency lock file
+- Using previously-installed hashicorp/local v2.5.3
+- Using previously-installed hashicorp/null v3.2.4
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+null_resource.servicio_a: Refreshing state... [id=8771288233724656698]
+local_file.servicio_dummy: Refreshing state... [id=c594e57e91da438c01aa19f3ce928b4c17b3ddc1]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service"
+      + id                   = (known after apply)
+    }
+
+Plan: 1 to add, 0 to change, 0 to destroy.
+local_file.servicio_dummy: Creating...
+local_file.servicio_dummy: Creation complete after 0s [id=51b168ddf90a232c8680c91b3bc3109c0b207ced]
+
+Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+Initializing the backend...
+Initializing modules...
+Initializing provider plugins...
+- Reusing previous version of hashicorp/null from the dependency lock file
+- Reusing previous version of hashicorp/local from the dependency lock file
+- Using previously-installed hashicorp/null v3.2.4
+- Using previously-installed hashicorp/local v2.5.3
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+module.servicio_a.null_resource.servicio_a: Refreshing state... [id=7594903794493526689]
+module.servicio_a.local_file.servicio_dummy: Refreshing state... [id=2ef91e06f3f28beee76efc8751f5e498020b3ac3]
+local_file.servicio_dummy: Refreshing state... [id=b9d03f612ad8800b094405fe2f297c4d9ca46040]
+null_resource.servicio_c: Refreshing state... [id=5189715582138057298]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/db_dummy.txt"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_a.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service"
+      + id                   = (known after apply)
+    }
+
+Plan: 2 to add, 0 to change, 0 to destroy.
+local_file.servicio_dummy: Creating...
+local_file.servicio_dummy: Creation complete after 0s [id=273749f0fc6e5dcc1004fe0bf0a089103b349fa6]
+module.servicio_a.local_file.servicio_dummy: Creating...
+module.servicio_a.local_file.servicio_dummy: Creation complete after 0s [id=8413caa1c114919230ad601d7f96dc3385cb322a]
+
+Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
+Initializing the backend...
+Initializing modules...
+Initializing provider plugins...
+- Reusing previous version of hashicorp/local from the dependency lock file
+- Reusing previous version of hashicorp/null from the dependency lock file
+- Using previously-installed hashicorp/local v2.5.3
+- Using previously-installed hashicorp/null v3.2.4
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+module.servicio_c.module.servicio_a.null_resource.servicio_a: Refreshing state... [id=8290191218549315080]
+local_file.servicio_dummy: Refreshing state... [id=6e8209badbb73dd361fabbe1f675dca58934c9ec]
+module.servicio_c.local_file.servicio_dummy: Refreshing state... [id=6c472d9c6a0a73e1a61f0cd958fa180c778e54d8]
+module.servicio_c.module.servicio_a.local_file.servicio_dummy: Refreshing state... [id=cb9a206441c6b878e6123dd02cf37479eea0432a]
+module.servicio_c.null_resource.servicio_c: Refreshing state... [id=4655234923691359330]
+null_resource.servicio_b: Refreshing state... [id=4364075706985955479]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_B.service"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_c.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/db_dummy.txt"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_c.module.servicio_a.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service"
+      + id                   = (known after apply)
+    }
+
+Plan: 3 to add, 0 to change, 0 to destroy.
+local_file.servicio_dummy: Creating...
+module.servicio_c.local_file.servicio_dummy: Creating...
+module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creating...
+module.servicio_c.local_file.servicio_dummy: Creation complete after 0s [id=37f7228ca34ab88c4c0e3d81bedfc35b4b0ada6e]
+local_file.servicio_dummy: Creation complete after 0s [id=4bc9adbfca64deb77bbd2655471021b9ba75b86b]
+module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creation complete after 0s [id=4bc9adbfca64deb77bbd2655471021b9ba75b86b]
+
+Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
+Initializing the backend...
+Initializing modules...
+Initializing provider plugins...
+- Reusing previous version of hashicorp/null from the dependency lock file
+- Reusing previous version of hashicorp/local from the dependency lock file
+- Using previously-installed hashicorp/local v2.5.3
+- Using previously-installed hashicorp/null v3.2.4
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+module.servicio_b.module.servicio_c.local_file.servicio_dummy: Refreshing state... [id=bff4c2be648ef590d16077f3cef4d7d57b01df58]
+module.servicio_b.local_file.servicio_dummy: Refreshing state... [id=a16b1d5415f235466844d1bc5700b1a93a8d1e72]
+module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy: Refreshing state... [id=1a75210eacd37ea03484efda4634fe9a8bb7aab4]
+module.servicio_b.module.servicio_c.module.servicio_a.null_resource.servicio_a: Refreshing state... [id=2258264413017640814]
+module.servicio_b.module.servicio_c.null_resource.servicio_c: Refreshing state... [id=4453232201833176036]
+module.servicio_b.null_resource.servicio_b: Refreshing state... [id=7760375672855320056]
+null_resource.servicio_d: Refreshing state... [id=3446376636890549700]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # module.servicio_b.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_B.service"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_b.module.servicio_c.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/db_dummy.txt"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service"
+      + id                   = (known after apply)
+    }
+
+Plan: 3 to add, 0 to change, 0 to destroy.
+module.servicio_b.local_file.servicio_dummy: Creating...
+module.servicio_b.module.servicio_c.local_file.servicio_dummy: Creating...
+module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creating...
+module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creation complete after 0s [id=cfb38be0fef83c5bf76b6a4d59990da4b2cb48e1]
+module.servicio_b.local_file.servicio_dummy: Creation complete after 0s [id=cfb38be0fef83c5bf76b6a4d59990da4b2cb48e1]
+module.servicio_b.module.servicio_c.local_file.servicio_dummy: Creation complete after 0s [id=4528cdf2a1ff2e561a8399cc18c9f8c7dd438ab3]
+
+Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

--- a/logs/deploy_20250618-232650.log
+++ b/logs/deploy_20250618-232650.log
@@ -1,0 +1,300 @@
+Initializing the backend...
+Initializing provider plugins...
+- Finding latest version of hashicorp/null...
+- Finding latest version of hashicorp/local...
+- Installing hashicorp/null v3.2.4...
+- Installed hashicorp/null v3.2.4 (signed by HashiCorp)
+- Installing hashicorp/local v2.5.3...
+- Installed hashicorp/local v2.5.3 (signed by HashiCorp)
+Terraform has created a lock file .terraform.lock.hcl to record the provider
+selections it made above. Include this file in your version control repository
+so that Terraform can guarantee to make the same selections by default when
+you run "terraform init" in the future.
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+null_resource.servicio_a: Refreshing state... [id=8771288233724656698]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service"
+      + id                   = (known after apply)
+    }
+
+Plan: 1 to add, 0 to change, 0 to destroy.
+local_file.servicio_dummy: Creating...
+local_file.servicio_dummy: Creation complete after 0s [id=ba478c51f2c2eb3e764cf1f8580d10f70e781d7f]
+
+Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+Initializing the backend...
+Initializing modules...
+- servicio_a in ../servicio_a
+Initializing provider plugins...
+- Finding latest version of hashicorp/null...
+- Finding latest version of hashicorp/local...
+- Installing hashicorp/null v3.2.4...
+- Installed hashicorp/null v3.2.4 (signed by HashiCorp)
+- Installing hashicorp/local v2.5.3...
+- Installed hashicorp/local v2.5.3 (signed by HashiCorp)
+Terraform has created a lock file .terraform.lock.hcl to record the provider
+selections it made above. Include this file in your version control repository
+so that Terraform can guarantee to make the same selections by default when
+you run "terraform init" in the future.
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+module.servicio_a.null_resource.servicio_a: Refreshing state... [id=7594903794493526689]
+null_resource.servicio_c: Refreshing state... [id=5189715582138057298]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # local_file.db_dummy will be created
+  + resource "local_file" "db_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/db_dummy.txt"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_a.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service"
+      + id                   = (known after apply)
+    }
+
+Plan: 2 to add, 0 to change, 0 to destroy.
+local_file.db_dummy: Creating...
+module.servicio_a.local_file.servicio_dummy: Creating...
+module.servicio_a.local_file.servicio_dummy: Creation complete after 0s [id=e8a19bfcb0fe0d1771c47eafcf8225f8c9e53aab]
+local_file.db_dummy: Creation complete after 0s [id=437e5408b86683e7d93dd6608a7222b43f8fc032]
+
+Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
+Initializing the backend...
+Initializing modules...
+- servicio_c in ../servicio_c
+- servicio_c.servicio_a in ../servicio_a
+Initializing provider plugins...
+- Finding latest version of hashicorp/null...
+- Finding latest version of hashicorp/local...
+- Installing hashicorp/null v3.2.4...
+- Installed hashicorp/null v3.2.4 (signed by HashiCorp)
+- Installing hashicorp/local v2.5.3...
+- Installed hashicorp/local v2.5.3 (signed by HashiCorp)
+Terraform has created a lock file .terraform.lock.hcl to record the provider
+selections it made above. Include this file in your version control repository
+so that Terraform can guarantee to make the same selections by default when
+you run "terraform init" in the future.
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+module.servicio_c.module.servicio_a.null_resource.servicio_a: Refreshing state... [id=8290191218549315080]
+module.servicio_c.null_resource.servicio_c: Refreshing state... [id=4655234923691359330]
+null_resource.servicio_b: Refreshing state... [id=4364075706985955479]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_B.service"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_c.local_file.db_dummy will be created
+  + resource "local_file" "db_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/db_dummy.txt"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_c.module.servicio_a.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service"
+      + id                   = (known after apply)
+    }
+
+Plan: 3 to add, 0 to change, 0 to destroy.
+local_file.servicio_dummy: Creating...
+module.servicio_c.local_file.db_dummy: Creating...
+module.servicio_c.local_file.db_dummy: Creation complete after 0s [id=07bea629a0b9e7dac8625a848197a55481859a3b]
+local_file.servicio_dummy: Creation complete after 0s [id=eb36b5729239f99034fa4167df9c2c8b5afa3417]
+module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creating...
+module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creation complete after 0s [id=eb36b5729239f99034fa4167df9c2c8b5afa3417]
+
+Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
+Initializing the backend...
+Initializing modules...
+- servicio_b in ../servicio_b
+- servicio_b.servicio_c in ../servicio_c
+- servicio_b.servicio_c.servicio_a in ../servicio_a
+Initializing provider plugins...
+- Finding latest version of hashicorp/local...
+- Finding latest version of hashicorp/null...
+- Installing hashicorp/null v3.2.4...
+- Installed hashicorp/null v3.2.4 (signed by HashiCorp)
+- Installing hashicorp/local v2.5.3...
+- Installed hashicorp/local v2.5.3 (signed by HashiCorp)
+Terraform has created a lock file .terraform.lock.hcl to record the provider
+selections it made above. Include this file in your version control repository
+so that Terraform can guarantee to make the same selections by default when
+you run "terraform init" in the future.
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+module.servicio_b.module.servicio_c.module.servicio_a.null_resource.servicio_a: Refreshing state... [id=2258264413017640814]
+module.servicio_b.module.servicio_c.null_resource.servicio_c: Refreshing state... [id=4453232201833176036]
+module.servicio_b.null_resource.servicio_b: Refreshing state... [id=7760375672855320056]
+null_resource.servicio_d: Refreshing state... [id=3446376636890549700]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # module.servicio_b.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_B.service"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_b.module.servicio_c.local_file.db_dummy will be created
+  + resource "local_file" "db_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/db_dummy.txt"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service"
+      + id                   = (known after apply)
+    }
+
+Plan: 3 to add, 0 to change, 0 to destroy.
+module.servicio_b.module.servicio_c.local_file.db_dummy: Creating...
+module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creating...
+module.servicio_b.local_file.servicio_dummy: Creating...
+module.servicio_b.module.servicio_c.local_file.db_dummy: Creation complete after 0s [id=5190e909ed5fb0c877888fbadcda116ddc849fae]
+module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creation complete after 0s [id=e62f2c33f185595e3bf30cd37c8a8643fb498e53]
+module.servicio_b.local_file.servicio_dummy: Creation complete after 0s [id=e62f2c33f185595e3bf30cd37c8a8643fb498e53]
+
+Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

--- a/logs/deploy_20250618-232910.log
+++ b/logs/deploy_20250618-232910.log
@@ -1,0 +1,300 @@
+Initializing the backend...
+Initializing provider plugins...
+- Finding latest version of hashicorp/local...
+- Finding latest version of hashicorp/null...
+- Installing hashicorp/null v3.2.4...
+- Installed hashicorp/null v3.2.4 (signed by HashiCorp)
+- Installing hashicorp/local v2.5.3...
+- Installed hashicorp/local v2.5.3 (signed by HashiCorp)
+Terraform has created a lock file .terraform.lock.hcl to record the provider
+selections it made above. Include this file in your version control repository
+so that Terraform can guarantee to make the same selections by default when
+you run "terraform init" in the future.
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+null_resource.servicio_a: Refreshing state... [id=8771288233724656698]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service"
+      + id                   = (known after apply)
+    }
+
+Plan: 1 to add, 0 to change, 0 to destroy.
+local_file.servicio_dummy: Creating...
+local_file.servicio_dummy: Creation complete after 0s [id=e93a551d25aca5ccae954efcf2f0c9dd17cca625]
+
+Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+Initializing the backend...
+Initializing modules...
+- servicio_a in ../servicio_a
+Initializing provider plugins...
+- Finding latest version of hashicorp/local...
+- Finding latest version of hashicorp/null...
+- Installing hashicorp/local v2.5.3...
+- Installed hashicorp/local v2.5.3 (signed by HashiCorp)
+- Installing hashicorp/null v3.2.4...
+- Installed hashicorp/null v3.2.4 (signed by HashiCorp)
+Terraform has created a lock file .terraform.lock.hcl to record the provider
+selections it made above. Include this file in your version control repository
+so that Terraform can guarantee to make the same selections by default when
+you run "terraform init" in the future.
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+module.servicio_a.null_resource.servicio_a: Refreshing state... [id=7594903794493526689]
+null_resource.servicio_c: Refreshing state... [id=5189715582138057298]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # local_file.db_dummy will be created
+  + resource "local_file" "db_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/db_dummy.txt"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_a.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service"
+      + id                   = (known after apply)
+    }
+
+Plan: 2 to add, 0 to change, 0 to destroy.
+module.servicio_a.local_file.servicio_dummy: Creating...
+local_file.db_dummy: Creating...
+module.servicio_a.local_file.servicio_dummy: Creation complete after 0s [id=49ae85a414daa5421f2c3f90f88490ec584e00cd]
+local_file.db_dummy: Creation complete after 0s [id=d2f39b8382f83c9a40591d8cb7508c81660866fc]
+
+Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
+Initializing the backend...
+Initializing modules...
+- servicio_c in ../servicio_c
+- servicio_c.servicio_a in ../servicio_a
+Initializing provider plugins...
+- Finding latest version of hashicorp/null...
+- Finding latest version of hashicorp/local...
+- Installing hashicorp/null v3.2.4...
+- Installed hashicorp/null v3.2.4 (signed by HashiCorp)
+- Installing hashicorp/local v2.5.3...
+- Installed hashicorp/local v2.5.3 (signed by HashiCorp)
+Terraform has created a lock file .terraform.lock.hcl to record the provider
+selections it made above. Include this file in your version control repository
+so that Terraform can guarantee to make the same selections by default when
+you run "terraform init" in the future.
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+module.servicio_c.module.servicio_a.null_resource.servicio_a: Refreshing state... [id=8290191218549315080]
+module.servicio_c.null_resource.servicio_c: Refreshing state... [id=4655234923691359330]
+null_resource.servicio_b: Refreshing state... [id=4364075706985955479]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_B.service"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_c.local_file.db_dummy will be created
+  + resource "local_file" "db_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/db_dummy.txt"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_c.module.servicio_a.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service"
+      + id                   = (known after apply)
+    }
+
+Plan: 3 to add, 0 to change, 0 to destroy.
+local_file.servicio_dummy: Creating...
+local_file.servicio_dummy: Creation complete after 0s [id=f8b00543a714fc97a1b911caa391324ce7881019]
+module.servicio_c.local_file.db_dummy: Creating...
+module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creating...
+module.servicio_c.local_file.db_dummy: Creation complete after 0s [id=ec9fcee56cf1dbe72afd0807fde9d1ae0b1bf03e]
+module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creation complete after 0s [id=f8b00543a714fc97a1b911caa391324ce7881019]
+
+Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
+Initializing the backend...
+Initializing modules...
+- servicio_b in ../servicio_b
+- servicio_b.servicio_c in ../servicio_c
+- servicio_b.servicio_c.servicio_a in ../servicio_a
+Initializing provider plugins...
+- Finding latest version of hashicorp/local...
+- Finding latest version of hashicorp/null...
+- Installing hashicorp/local v2.5.3...
+- Installed hashicorp/local v2.5.3 (signed by HashiCorp)
+- Installing hashicorp/null v3.2.4...
+- Installed hashicorp/null v3.2.4 (signed by HashiCorp)
+Terraform has created a lock file .terraform.lock.hcl to record the provider
+selections it made above. Include this file in your version control repository
+so that Terraform can guarantee to make the same selections by default when
+you run "terraform init" in the future.
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+module.servicio_b.module.servicio_c.module.servicio_a.null_resource.servicio_a: Refreshing state... [id=2258264413017640814]
+module.servicio_b.module.servicio_c.null_resource.servicio_c: Refreshing state... [id=4453232201833176036]
+module.servicio_b.null_resource.servicio_b: Refreshing state... [id=7760375672855320056]
+null_resource.servicio_d: Refreshing state... [id=3446376636890549700]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # module.servicio_b.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_B.service"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_b.module.servicio_c.local_file.db_dummy will be created
+  + resource "local_file" "db_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/db_dummy.txt"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service"
+      + id                   = (known after apply)
+    }
+
+Plan: 3 to add, 0 to change, 0 to destroy.
+module.servicio_b.local_file.servicio_dummy: Creating...
+module.servicio_b.module.servicio_c.local_file.db_dummy: Creating...
+module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creating...
+module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creation complete after 0s [id=9be84c3998e41b609c094b8e8850070e13af96fc]
+module.servicio_b.local_file.servicio_dummy: Creation complete after 0s [id=9be84c3998e41b609c094b8e8850070e13af96fc]
+module.servicio_b.module.servicio_c.local_file.db_dummy: Creation complete after 0s [id=3e9f959545cdd5492392e0fdbfd6a1821752c5e7]
+
+Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

--- a/logs/deploy_20250618-233345.log
+++ b/logs/deploy_20250618-233345.log
@@ -1,0 +1,270 @@
+Initializing the backend...
+Initializing provider plugins...
+- Reusing previous version of hashicorp/local from the dependency lock file
+- Reusing previous version of hashicorp/null from the dependency lock file
+- Using previously-installed hashicorp/local v2.5.3
+- Using previously-installed hashicorp/null v3.2.4
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+null_resource.servicio_a: Refreshing state... [id=8771288233724656698]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service"
+      + id                   = (known after apply)
+    }
+
+Plan: 1 to add, 0 to change, 0 to destroy.
+local_file.servicio_dummy: Creating...
+local_file.servicio_dummy: Creation complete after 0s [id=fe03b15c0f822b25d8158ceccf2cd5707e79b6d5]
+
+Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+Initializing the backend...
+Initializing modules...
+Initializing provider plugins...
+- Reusing previous version of hashicorp/local from the dependency lock file
+- Reusing previous version of hashicorp/null from the dependency lock file
+- Using previously-installed hashicorp/local v2.5.3
+- Using previously-installed hashicorp/null v3.2.4
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+module.servicio_a.null_resource.servicio_a: Refreshing state... [id=7594903794493526689]
+null_resource.servicio_c: Refreshing state... [id=5189715582138057298]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # local_file.db_dummy will be created
+  + resource "local_file" "db_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/db_dummy.txt"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_a.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service"
+      + id                   = (known after apply)
+    }
+
+Plan: 2 to add, 0 to change, 0 to destroy.
+module.servicio_a.local_file.servicio_dummy: Creating...
+local_file.db_dummy: Creating...
+module.servicio_a.local_file.servicio_dummy: Creation complete after 0s [id=5b2b65cab73981cbeb0def8932cecedb3ff375cd]
+local_file.db_dummy: Creation complete after 0s [id=9ebf5578bc9c60a6f024253e51df11f8f6559878]
+
+Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
+Initializing the backend...
+Initializing modules...
+Initializing provider plugins...
+- Reusing previous version of hashicorp/local from the dependency lock file
+- Reusing previous version of hashicorp/null from the dependency lock file
+- Using previously-installed hashicorp/local v2.5.3
+- Using previously-installed hashicorp/null v3.2.4
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+module.servicio_c.module.servicio_a.null_resource.servicio_a: Refreshing state... [id=8290191218549315080]
+module.servicio_c.null_resource.servicio_c: Refreshing state... [id=4655234923691359330]
+null_resource.servicio_b: Refreshing state... [id=4364075706985955479]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_B.service"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_c.local_file.db_dummy will be created
+  + resource "local_file" "db_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/db_dummy.txt"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_c.module.servicio_a.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service"
+      + id                   = (known after apply)
+    }
+
+Plan: 3 to add, 0 to change, 0 to destroy.
+local_file.servicio_dummy: Creating...
+local_file.servicio_dummy: Creation complete after 0s [id=9fdc6d66258759ec2e006259ac3ca8ea7e08b166]
+module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creating...
+module.servicio_c.local_file.db_dummy: Creating...
+module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creation complete after 0s [id=9fdc6d66258759ec2e006259ac3ca8ea7e08b166]
+module.servicio_c.local_file.db_dummy: Creation complete after 0s [id=eae5884947c2294bbea82a2dbd9672566f91bd32]
+
+Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
+Initializing the backend...
+Initializing modules...
+Initializing provider plugins...
+- Reusing previous version of hashicorp/null from the dependency lock file
+- Reusing previous version of hashicorp/local from the dependency lock file
+- Using previously-installed hashicorp/null v3.2.4
+- Using previously-installed hashicorp/local v2.5.3
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+module.servicio_b.module.servicio_c.module.servicio_a.null_resource.servicio_a: Refreshing state... [id=2258264413017640814]
+module.servicio_b.module.servicio_c.null_resource.servicio_c: Refreshing state... [id=4453232201833176036]
+module.servicio_b.null_resource.servicio_b: Refreshing state... [id=7760375672855320056]
+null_resource.servicio_d: Refreshing state... [id=3446376636890549700]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # module.servicio_b.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_B.service"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_b.module.servicio_c.local_file.db_dummy will be created
+  + resource "local_file" "db_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/db_dummy.txt"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service"
+      + id                   = (known after apply)
+    }
+
+Plan: 3 to add, 0 to change, 0 to destroy.
+module.servicio_b.local_file.servicio_dummy: Creating...
+module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creating...
+module.servicio_b.local_file.servicio_dummy: Creation complete after 0s [id=b96e6520a3032c904821db79a9af93276cae971d]
+module.servicio_b.module.servicio_c.local_file.db_dummy: Creating...
+module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creation complete after 0s [id=b96e6520a3032c904821db79a9af93276cae971d]
+module.servicio_b.module.servicio_c.local_file.db_dummy: Creation complete after 0s [id=3d2c379ad974f5b05396ed071277eda29fdd19d6]
+
+Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

--- a/logs/deploy_20250618-234242.log
+++ b/logs/deploy_20250618-234242.log
@@ -1,0 +1,279 @@
+Initializing the backend...
+Initializing provider plugins...
+- Reusing previous version of hashicorp/local from the dependency lock file
+- Reusing previous version of hashicorp/null from the dependency lock file
+- Using previously-installed hashicorp/local v2.5.3
+- Using previously-installed hashicorp/null v3.2.4
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+local_file.servicio_dummy: Refreshing state... [id=fe03b15c0f822b25d8158ceccf2cd5707e79b6d5]
+null_resource.servicio_a: Refreshing state... [id=8771288233724656698]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service"
+      + id                   = (known after apply)
+    }
+
+Plan: 1 to add, 0 to change, 0 to destroy.
+local_file.servicio_dummy: Creating...
+local_file.servicio_dummy: Creation complete after 0s [id=027f0369ab1119b9be3f41880668702b6d473e63]
+
+Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+Initializing the backend...
+Initializing modules...
+Initializing provider plugins...
+- Reusing previous version of hashicorp/null from the dependency lock file
+- Reusing previous version of hashicorp/local from the dependency lock file
+- Using previously-installed hashicorp/null v3.2.4
+- Using previously-installed hashicorp/local v2.5.3
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+module.servicio_a.null_resource.servicio_a: Refreshing state... [id=7594903794493526689]
+local_file.db_dummy: Refreshing state... [id=9ebf5578bc9c60a6f024253e51df11f8f6559878]
+module.servicio_a.local_file.servicio_dummy: Refreshing state... [id=5b2b65cab73981cbeb0def8932cecedb3ff375cd]
+null_resource.servicio_c: Refreshing state... [id=5189715582138057298]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # local_file.db_dummy will be created
+  + resource "local_file" "db_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/db_dummy.txt"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_a.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service"
+      + id                   = (known after apply)
+    }
+
+Plan: 2 to add, 0 to change, 0 to destroy.
+local_file.db_dummy: Creating...
+module.servicio_a.local_file.servicio_dummy: Creating...
+local_file.db_dummy: Creation complete after 0s [id=7453bf338c6135145aeb26a89cc8b5359fc5098b]
+module.servicio_a.local_file.servicio_dummy: Creation complete after 0s [id=a38f5d913f0220adee4b3add1bd28554c162c225]
+
+Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
+Initializing the backend...
+Initializing modules...
+Initializing provider plugins...
+- Reusing previous version of hashicorp/null from the dependency lock file
+- Reusing previous version of hashicorp/local from the dependency lock file
+- Using previously-installed hashicorp/null v3.2.4
+- Using previously-installed hashicorp/local v2.5.3
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+module.servicio_c.module.servicio_a.local_file.servicio_dummy: Refreshing state... [id=9fdc6d66258759ec2e006259ac3ca8ea7e08b166]
+local_file.servicio_dummy: Refreshing state... [id=9fdc6d66258759ec2e006259ac3ca8ea7e08b166]
+module.servicio_c.local_file.db_dummy: Refreshing state... [id=eae5884947c2294bbea82a2dbd9672566f91bd32]
+module.servicio_c.module.servicio_a.null_resource.servicio_a: Refreshing state... [id=8290191218549315080]
+module.servicio_c.null_resource.servicio_c: Refreshing state... [id=4655234923691359330]
+null_resource.servicio_b: Refreshing state... [id=4364075706985955479]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_B.service"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_c.local_file.db_dummy will be created
+  + resource "local_file" "db_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/db_dummy.txt"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_c.module.servicio_a.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service"
+      + id                   = (known after apply)
+    }
+
+Plan: 3 to add, 0 to change, 0 to destroy.
+module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creating...
+module.servicio_c.local_file.db_dummy: Creating...
+local_file.servicio_dummy: Creating...
+local_file.servicio_dummy: Creation complete after 0s [id=5bfabda6b02397fb709a162dc4a350bbcac83b8b]
+module.servicio_c.local_file.db_dummy: Creation complete after 0s [id=0d4a2bdaeef2c10700d205577922518e890a5ff3]
+module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creation complete after 0s [id=5bfabda6b02397fb709a162dc4a350bbcac83b8b]
+
+Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
+Initializing the backend...
+Initializing modules...
+Initializing provider plugins...
+- Reusing previous version of hashicorp/null from the dependency lock file
+- Reusing previous version of hashicorp/local from the dependency lock file
+- Using previously-installed hashicorp/null v3.2.4
+- Using previously-installed hashicorp/local v2.5.3
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+module.servicio_b.module.servicio_c.module.servicio_a.null_resource.servicio_a: Refreshing state... [id=2258264413017640814]
+module.servicio_b.module.servicio_c.local_file.db_dummy: Refreshing state... [id=3d2c379ad974f5b05396ed071277eda29fdd19d6]
+module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy: Refreshing state... [id=b96e6520a3032c904821db79a9af93276cae971d]
+module.servicio_b.local_file.servicio_dummy: Refreshing state... [id=b96e6520a3032c904821db79a9af93276cae971d]
+module.servicio_b.module.servicio_c.null_resource.servicio_c: Refreshing state... [id=4453232201833176036]
+module.servicio_b.null_resource.servicio_b: Refreshing state... [id=7760375672855320056]
+null_resource.servicio_d: Refreshing state... [id=3446376636890549700]
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # module.servicio_b.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_B.service"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_b.module.servicio_c.local_file.db_dummy will be created
+  + resource "local_file" "db_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/db_dummy.txt"
+      + id                   = (known after apply)
+    }
+
+  # module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy will be created
+  + resource "local_file" "servicio_dummy" {
+      + content              = (known after apply)
+      + content_base64sha256 = (known after apply)
+      + content_base64sha512 = (known after apply)
+      + content_md5          = (known after apply)
+      + content_sha1         = (known after apply)
+      + content_sha256       = (known after apply)
+      + content_sha512       = (known after apply)
+      + directory_permission = "0777"
+      + file_permission      = "0777"
+      + filename             = "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service"
+      + id                   = (known after apply)
+    }
+
+Plan: 3 to add, 0 to change, 0 to destroy.
+module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creating...
+module.servicio_b.local_file.servicio_dummy: Creating...
+module.servicio_b.module.servicio_c.local_file.db_dummy: Creating...
+module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy: Creation complete after 0s [id=9cb27978bc2cf5bd5cc35f5ef637fda3e9fdd6a2]
+module.servicio_b.local_file.servicio_dummy: Creation complete after 0s [id=9cb27978bc2cf5bd5cc35f5ef637fda3e9fdd6a2]
+module.servicio_b.module.servicio_c.local_file.db_dummy: Creation complete after 0s [id=d811e1a1422bd1bcde4a8740d631a9dbe4a447c4]
+
+Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

--- a/scripts/guarda_tag_state.sh
+++ b/scripts/guarda_tag_state.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/bash
+
+TAG=$1
+
+if [[ $# -ne 1 ]]; then
+    echo "Debe ingresar el nombre del tag. Debe tener este formato vX.Y.Z"
+    exit 1
+fi
+
+read -p "Ingresa el mensaje del tag $TAG: " mensaje
+MODULOS=("servicio_a" "servicio_b" "servicio_c" "servicio_d")
+DIR_TR=terraform
+DIR_TAG=$(echo "$TAG" | sed 's/\./_/g')
+DIR_BACKUPS="backups/$DIR_TAG"
+mkdir -p $DIR_BACKUPS
+echo ""
+echo "Copiando los archivos tfstate hacia el directorio $DIR_BACKUPS"
+
+for modulo in ${MODULOS[@]}; do
+    mkdir -p "$DIR_BACKUPS/$modulo"
+    cp "$DIR_TR/$modulo/terraform.tfstate" "$DIR_BACKUPS/$modulo/tfstate_$TAG.tfstate"
+    echo "El archivo 'terraform.tfstate' de $modulo se ha copiado a '$DIR_BACKUPS/$modulo'"
+done
+echo ""
+echo "Se creará el tag $TAG con el mensaje: '$mensaje'"
+git tag -a $TAG -m "$mensaje"
+echo ""
+if [[ $? -eq 0 ]]; then
+    echo "Se ha creado el tag exitosamente"
+else
+    echo "Error al crear el tag"
+    exit 1
+fi
+

--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/bash
+
+#set -e
+
+TAG=$1
+LRED='\033[0;31m'
+NC='\033[0m'
+
+if [ $# -ne 1 ]; then
+    echo "Debe ingresar un tag"
+    exit 1
+fi
+
+git show $TAG >> /tmp/rollback.log 2>&1
+if [ $? -ne 0 ]; then
+    echo -e "${LRED}El tag '$TAG' no existe${NC}"
+    exit 1
+fi
+
+echo "El tag '$TAG' existe"
+TIMESTAMP=$(date +%Y-%m-%d_%H-%M-%S)
+git checkout $TAG >> /tmp/rollback_$TIMESTAMP.log 2>&1
+
+if [ $? -ne 0 ]; then 
+    echo -e "${LRED}Hay cambios sin confirmar. Confirma o guarda tus cambios (stash)${NC}"
+    exit 1
+fi
+
+echo "Restaurando a version $TAG"
+./scripts/hola.sh
+
+
+# Añadir **funcionalidad avanzada** de rollback local:
+ #* Script `rollback.sh` que, dado un tag Git (p. ej., `v-0`), 
+ # restaure el estado de `terraform.tfstate` correspondiente y 
+ # ejecute `terraform apply` para volver al despliegue previo.
+ #* El script debe:
+	#* Validar que el tag existe.
+	#* Copiar el backup de estado en `backups/tfstate_vX.tfstate`.
+	#* Forzar el estado local y aplicar el plan.

--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -27,7 +27,7 @@ if [ $? -ne 0 ]; then
 fi
 
 echo "Restaurando a version $TAG"
-./scripts/hola.sh
+./scripts/deploy_all.sh
 
 
 # Añadir **funcionalidad avanzada** de rollback local:

--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -26,6 +26,6 @@ for modulo in ${MODULOS[@]}; do
     cp -p "$DIR_BACKUPS/$modulo/tfstate_$TAG.tfstate" "terraform/$modulo/terraform.tfstate"
 done
 
-echo "${GREEN}Restaurando a version ${TAG}${NC}"
+echo -e "${GREEN}Restaurando a version ${TAG}${NC}"
 echo ""
 ./scripts/deploy_all.sh

--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/bash
 
-#set -e
-
 TAG=$1
 LRED='\033[0;31m'
+GREEN='\033[0;32m'
 NC='\033[0m'
 
 if [ $# -ne 1 ]; then
@@ -18,23 +17,15 @@ if [ $? -ne 0 ]; then
 fi
 
 echo "El tag '$TAG' existe"
-TIMESTAMP=$(date +%Y-%m-%d_%H-%M-%S)
-git checkout $TAG >> /tmp/rollback_$TIMESTAMP.log 2>&1
+DIR_TR="terraform"
+MODULOS=("servicio_a" "servicio_c" "servicio_b" "servicio_d")
+DIR_TAG=$(echo "$TAG" | sed 's/\./_/g')
+DIR_BACKUPS="backups/$DIR_TAG"
 
-if [ $? -ne 0 ]; then 
-    echo -e "${LRED}Hay cambios sin confirmar. Confirma o guarda tus cambios (stash)${NC}"
-    exit 1
-fi
+for modulo in ${MODULOS[@]}; do
+    cp -p "$DIR_BACKUPS/$modulo/tfstate_$TAG.tfstate" "terraform/$modulo/terraform.tfstate"
+done
 
-echo "Restaurando a version $TAG"
+echo "${GREEN}Restaurando a version ${TAG}${NC}"
+echo ""
 ./scripts/deploy_all.sh
-
-
-# Añadir **funcionalidad avanzada** de rollback local:
- #* Script `rollback.sh` que, dado un tag Git (p. ej., `v-0`), 
- # restaure el estado de `terraform.tfstate` correspondiente y 
- # ejecute `terraform apply` para volver al despliegue previo.
- #* El script debe:
-	#* Validar que el tag existe.
-	#* Copiar el backup de estado en `backups/tfstate_vX.tfstate`.
-	#* Forzar el estado local y aplicar el plan.

--- a/servicios_simulados/db_dummy.txt
+++ b/servicios_simulados/db_dummy.txt
@@ -1,1 +1,0 @@
-Base de datos creada el 2025-06-18 a las 00:03:52

--- a/servicios_simulados/servicio_dummy_A.service
+++ b/servicios_simulados/servicio_dummy_A.service
@@ -1,1 +1,0 @@
-Servicio dummy instalado el 2025-06-18 a las 00:03:49

--- a/servicios_simulados/servicio_dummy_B.service
+++ b/servicios_simulados/servicio_dummy_B.service
@@ -1,1 +1,0 @@
-Servicio dummy instalado el 2025-06-18 a las 00:03:55

--- a/terraform/servicio_a/.terraform.lock.hcl
+++ b/terraform/servicio_a/.terraform.lock.hcl
@@ -1,6 +1,25 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.5.3"
+  hashes = [
+    "h1:1Nkh16jQJMp0EuDmvP/96f5Unnir0z12WyDuoR6HjMo=",
+    "zh:284d4b5b572eacd456e605e94372f740f6de27b71b4e1fd49b63745d8ecd4927",
+    "zh:40d9dfc9c549e406b5aab73c023aa485633c1b6b730c933d7bcc2fa67fd1ae6e",
+    "zh:6243509bb208656eb9dc17d3c525c89acdd27f08def427a0dce22d5db90a4c8b",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:885d85869f927853b6fe330e235cd03c337ac3b933b0d9ae827ec32fa1fdcdbf",
+    "zh:bab66af51039bdfcccf85b25fe562cbba2f54f6b3812202f4873ade834ec201d",
+    "zh:c505ff1bf9442a889ac7dca3ac05a8ee6f852e0118dd9a61796a2f6ff4837f09",
+    "zh:d36c0b5770841ddb6eaf0499ba3de48e5d4fc99f4829b6ab66b0fab59b1aaf4f",
+    "zh:ddb6a407c7f3ec63efb4dad5f948b54f7f4434ee1a2607a49680d494b1776fe1",
+    "zh:e0dafdd4500bec23d3ff221e3a9b60621c5273e5df867bc59ef6b7e41f5c91f6",
+    "zh:ece8742fd2882a8fc9d6efd20e2590010d43db386b920b2a9c220cfecc18de47",
+    "zh:f4c6b3eb8f39105004cf720e202f04f57e3578441cfb76ca27611139bc116a82",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/null" {
   version = "3.2.4"
   hashes = [

--- a/terraform/servicio_a/.terraform/providers/registry.terraform.io/hashicorp/local/2.5.3/linux_amd64/LICENSE.txt
+++ b/terraform/servicio_a/.terraform/providers/registry.terraform.io/hashicorp/local/2.5.3/linux_amd64/LICENSE.txt
@@ -1,0 +1,375 @@
+Copyright (c) 2017 HashiCorp, Inc.
+
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/terraform/servicio_a/main.tf
+++ b/terraform/servicio_a/main.tf
@@ -12,6 +12,7 @@ locals {
 
   ruta_raiz_proyecto       = abspath("${path.module}/../../")
   ruta_servicios_simulados = abspath("${path.module}/../../servicios_simulados")
+  hora_local               = timeadd(timestamp(), "-5h")
 
 }
 
@@ -20,6 +21,12 @@ variable "service_name" {
   type        = string
   default     = "servicio_dummy_A.service"
 }
+
+resource "local_file" "servicio_dummy" {
+  filename = "${local.ruta_servicios_simulados}/${var.service_name}"
+  content  = "Servicio creado a las ${formatdate("YYYY-MM-DD hh:mm:ss", local.hora_local)}"
+}
+
 
 
 resource "null_resource" "servicio_a" {
@@ -32,7 +39,5 @@ resource "null_resource" "servicio_a" {
 
   provisioner "local-exec" {
     command = "${local.ruta_raiz_proyecto}/scripts/instala_servicio.sh ${var.service_name} ${local.ruta_servicios_simulados}"
-    # command = "if [ ! -f \"${var.ruta_servicios_simulados}/${var.service_name}\" ]; then ${var.ruta_raiz_proyecto}/scripts/instala_servicio.sh ${var.service_name} ${var.ruta_servicios_simulados}; fi"
-    # interpreter = ["bash", "-c"]
   }
 }

--- a/terraform/servicio_a/terraform.tfstate
+++ b/terraform/servicio_a/terraform.tfstate
@@ -1,10 +1,46 @@
 {
   "version": 4,
   "terraform_version": "1.12.1",
-  "serial": 1,
+  "serial": 5,
   "lineage": "bbe75eea-6168-3b0b-8d7d-17ac97ee5f25",
   "outputs": {},
   "resources": [
+    {
+      "mode": "managed",
+      "type": "local_file",
+      "name": "servicio_dummy",
+      "provider": "provider[\"registry.terraform.io/hashicorp/local\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "content": "Servicio creado a las 2025-06-18 23:42:44",
+            "content_base64": null,
+            "content_base64sha256": "dQUwuD/hqvLK2YMWLAzUzQBmCMSwvRMc3u7rIC9HO14=",
+            "content_base64sha512": "csBBwVlNOF/vZE2/Y2/r+vHswxoJZ9IqfTWFrKCkU6l+33zm8K/+NJqAS0TNBhg1N1YZQ21j8ll9WNVOA1hCcw==",
+            "content_md5": "762287d06659477dcf26230252d0d91d",
+            "content_sha1": "027f0369ab1119b9be3f41880668702b6d473e63",
+            "content_sha256": "750530b83fe1aaf2cad983162c0cd4cd006608c4b0bd131cdeeeeb202f473b5e",
+            "content_sha512": "72c041c1594d385fef644dbf636febfaf1ecc31a0967d22a7d3585aca0a453a97edf7ce6f0affe349a804b44cd061835375619436d63f2597d58d54e03584273",
+            "directory_permission": "0777",
+            "file_permission": "0777",
+            "filename": "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service",
+            "id": "027f0369ab1119b9be3f41880668702b6d473e63",
+            "sensitive_content": null,
+            "source": null
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "sensitive_content"
+              }
+            ]
+          ],
+          "identity_schema_version": 0
+        }
+      ]
+    },
     {
       "mode": "managed",
       "type": "null_resource",

--- a/terraform/servicio_a/terraform.tfstate
+++ b/terraform/servicio_a/terraform.tfstate
@@ -2,7 +2,7 @@
   "version": 4,
   "terraform_version": "1.12.1",
   "serial": 1,
-  "lineage": "8afd2e82-2b58-75ee-c19a-11d1a2a21dfc",
+  "lineage": "bbe75eea-6168-3b0b-8d7d-17ac97ee5f25",
   "outputs": {},
   "resources": [
     {
@@ -14,7 +14,7 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "3332120025483767566",
+            "id": "8771288233724656698",
             "triggers": null
           },
           "sensitive_attributes": [],

--- a/terraform/servicio_a/terraform.tfstate.backup
+++ b/terraform/servicio_a/terraform.tfstate.backup
@@ -1,0 +1,63 @@
+{
+  "version": 4,
+  "terraform_version": "1.12.1",
+  "serial": 3,
+  "lineage": "bbe75eea-6168-3b0b-8d7d-17ac97ee5f25",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "local_file",
+      "name": "servicio_dummy",
+      "provider": "provider[\"registry.terraform.io/hashicorp/local\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "content": "Servicio creado a las 2025-06-18 23:33:47",
+            "content_base64": null,
+            "content_base64sha256": "MNGGMwULd5kgN6/ZfwxnXVezVj9ngmmDNRwWGHLdDDo=",
+            "content_base64sha512": "znijRzSmcNXbPWf3LNIjyRUmR/1Exq6GZ6NRosg7kYdiO9PTnklMyaRVFLU4bYS1wEuaFcbLghr92RoC1bpQ8w==",
+            "content_md5": "9874befcab8a5a02d9a85faf930e5afd",
+            "content_sha1": "fe03b15c0f822b25d8158ceccf2cd5707e79b6d5",
+            "content_sha256": "30d18633050b77992037afd97f0c675d57b3563f67826983351c161872dd0c3a",
+            "content_sha512": "ce78a34734a670d5db3d67f72cd223c9152647fd44c6ae8667a351a2c83b9187623bd3d39e494cc9a45514b5386d84b5c04b9a15c6cb821afdd91a02d5ba50f3",
+            "directory_permission": "0777",
+            "file_permission": "0777",
+            "filename": "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service",
+            "id": "fe03b15c0f822b25d8158ceccf2cd5707e79b6d5",
+            "sensitive_content": null,
+            "source": null
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "sensitive_content"
+              }
+            ]
+          ],
+          "identity_schema_version": 0
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "servicio_a",
+      "provider": "provider[\"registry.terraform.io/hashicorp/null\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "8771288233724656698",
+            "triggers": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0
+        }
+      ]
+    }
+  ],
+  "check_results": null
+}

--- a/terraform/servicio_b/.terraform.lock.hcl
+++ b/terraform/servicio_b/.terraform.lock.hcl
@@ -1,6 +1,25 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.5.3"
+  hashes = [
+    "h1:1Nkh16jQJMp0EuDmvP/96f5Unnir0z12WyDuoR6HjMo=",
+    "zh:284d4b5b572eacd456e605e94372f740f6de27b71b4e1fd49b63745d8ecd4927",
+    "zh:40d9dfc9c549e406b5aab73c023aa485633c1b6b730c933d7bcc2fa67fd1ae6e",
+    "zh:6243509bb208656eb9dc17d3c525c89acdd27f08def427a0dce22d5db90a4c8b",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:885d85869f927853b6fe330e235cd03c337ac3b933b0d9ae827ec32fa1fdcdbf",
+    "zh:bab66af51039bdfcccf85b25fe562cbba2f54f6b3812202f4873ade834ec201d",
+    "zh:c505ff1bf9442a889ac7dca3ac05a8ee6f852e0118dd9a61796a2f6ff4837f09",
+    "zh:d36c0b5770841ddb6eaf0499ba3de48e5d4fc99f4829b6ab66b0fab59b1aaf4f",
+    "zh:ddb6a407c7f3ec63efb4dad5f948b54f7f4434ee1a2607a49680d494b1776fe1",
+    "zh:e0dafdd4500bec23d3ff221e3a9b60621c5273e5df867bc59ef6b7e41f5c91f6",
+    "zh:ece8742fd2882a8fc9d6efd20e2590010d43db386b920b2a9c220cfecc18de47",
+    "zh:f4c6b3eb8f39105004cf720e202f04f57e3578441cfb76ca27611139bc116a82",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/null" {
   version = "3.2.4"
   hashes = [

--- a/terraform/servicio_b/.terraform/providers/registry.terraform.io/hashicorp/local/2.5.3/linux_amd64/LICENSE.txt
+++ b/terraform/servicio_b/.terraform/providers/registry.terraform.io/hashicorp/local/2.5.3/linux_amd64/LICENSE.txt
@@ -1,0 +1,375 @@
+Copyright (c) 2017 HashiCorp, Inc.
+
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/terraform/servicio_b/main.tf
+++ b/terraform/servicio_b/main.tf
@@ -8,7 +8,7 @@ locals {
 
   ruta_raiz_proyecto       = abspath("${path.module}/../../")
   ruta_servicios_simulados = abspath("${path.module}/../../servicios_simulados")
-
+  hora_local               = timeadd(timestamp(), "-5h")
 }
 
 # variable ruta_raiz_proyecto {
@@ -27,6 +27,10 @@ variable "service_name" {
   default     = "servicio_dummy_B.service"
 }
 
+resource "local_file" "servicio_dummy" {
+  filename = "${local.ruta_servicios_simulados}/${var.service_name}"
+  content  = "Servicio creado a las ${formatdate("YYYY-MM-DD hh:mm:ss", local.hora_local)}"
+}
 
 resource "null_resource" "servicio_b" {
 

--- a/terraform/servicio_b/terraform.tfstate
+++ b/terraform/servicio_b/terraform.tfstate
@@ -2,7 +2,7 @@
   "version": 4,
   "terraform_version": "1.12.1",
   "serial": 4,
-  "lineage": "d7f02e98-1124-bb3c-2918-a429a8eadfd2",
+  "lineage": "12b86e99-50d0-b059-56c8-d3b1ed12b791",
   "outputs": {},
   "resources": [
     {
@@ -14,7 +14,7 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "7683387827655639121",
+            "id": "4364075706985955479",
             "triggers": null
           },
           "sensitive_attributes": [],
@@ -36,7 +36,7 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "260712122322409309",
+            "id": "4655234923691359330",
             "triggers": null
           },
           "sensitive_attributes": [],
@@ -57,7 +57,7 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "1724545409330666506",
+            "id": "8290191218549315080",
             "triggers": null
           },
           "sensitive_attributes": [],

--- a/terraform/servicio_b/terraform.tfstate
+++ b/terraform/servicio_b/terraform.tfstate
@@ -1,10 +1,46 @@
 {
   "version": 4,
   "terraform_version": "1.12.1",
-  "serial": 4,
+  "serial": 12,
   "lineage": "12b86e99-50d0-b059-56c8-d3b1ed12b791",
   "outputs": {},
   "resources": [
+    {
+      "mode": "managed",
+      "type": "local_file",
+      "name": "servicio_dummy",
+      "provider": "provider[\"registry.terraform.io/hashicorp/local\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "content": "Servicio creado a las 2025-06-18 23:42:47",
+            "content_base64": null,
+            "content_base64sha256": "62CfQur2e51Bih/AM8FN0iEUlMx5FRulcCaA+QJZTPg=",
+            "content_base64sha512": "Jw+SF+VCsE8xlHgDubxQ2pIHn4RYYWga2m2j7VlToRv1ipUN4UKWB7fagWRxAZ480TJvkSO3ijEw3AiKSjCxIw==",
+            "content_md5": "5bab79ebd68bf1e947569e8e587f165f",
+            "content_sha1": "5bfabda6b02397fb709a162dc4a350bbcac83b8b",
+            "content_sha256": "eb609f42eaf67b9d418a1fc033c14dd2211494cc79151ba5702680f902594cf8",
+            "content_sha512": "270f9217e542b04f31947803b9bc50da92079f845861681ada6da3ed5953a11bf58a950de1429607b7da816471019e3cd1326f9123b78a3130dc088a4a30b123",
+            "directory_permission": "0777",
+            "file_permission": "0777",
+            "filename": "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_B.service",
+            "id": "5bfabda6b02397fb709a162dc4a350bbcac83b8b",
+            "sensitive_content": null,
+            "source": null
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "sensitive_content"
+              }
+            ]
+          ],
+          "identity_schema_version": 0
+        }
+      ]
+    },
     {
       "mode": "managed",
       "type": "null_resource",
@@ -20,9 +56,48 @@
           "sensitive_attributes": [],
           "identity_schema_version": 0,
           "dependencies": [
+            "module.servicio_c.local_file.db_dummy",
+            "module.servicio_c.module.servicio_a.local_file.servicio_dummy",
             "module.servicio_c.module.servicio_a.null_resource.servicio_a",
             "module.servicio_c.null_resource.servicio_c"
           ]
+        }
+      ]
+    },
+    {
+      "module": "module.servicio_c",
+      "mode": "managed",
+      "type": "local_file",
+      "name": "db_dummy",
+      "provider": "provider[\"registry.terraform.io/hashicorp/local\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "content": "Base de datos creada a las 2025-06-18 23:42:47",
+            "content_base64": null,
+            "content_base64sha256": "PGsLG3utSDEiAETM8Gg32bUigJGPet/DgafvrEuTbBQ=",
+            "content_base64sha512": "6B+yXa9iCoXnl1Ce0S7M/CjEJay9sB3xIQKmBBkgEyqfgPpaow2ddcEb7iRTTUNl/9a5ctiT3Rrry5ogaTq28Q==",
+            "content_md5": "ccc1f9e5caf3656521b4ba227916c38e",
+            "content_sha1": "0d4a2bdaeef2c10700d205577922518e890a5ff3",
+            "content_sha256": "3c6b0b1b7bad4831220044ccf06837d9b52280918f7adfc381a7efac4b936c14",
+            "content_sha512": "e81fb25daf620a85e797509ed12eccfc28c425acbdb01df12102a6041920132a9f80fa5aa30d9d75c11bee24534d4365ffd6b972d893dd1aebcb9a20693ab6f1",
+            "directory_permission": "0777",
+            "file_permission": "0777",
+            "filename": "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/db_dummy.txt",
+            "id": "0d4a2bdaeef2c10700d205577922518e890a5ff3",
+            "sensitive_content": null,
+            "source": null
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "sensitive_content"
+              }
+            ]
+          ],
+          "identity_schema_version": 0
         }
       ]
     },
@@ -42,8 +117,46 @@
           "sensitive_attributes": [],
           "identity_schema_version": 0,
           "dependencies": [
+            "module.servicio_c.module.servicio_a.local_file.servicio_dummy",
             "module.servicio_c.module.servicio_a.null_resource.servicio_a"
           ]
+        }
+      ]
+    },
+    {
+      "module": "module.servicio_c.module.servicio_a",
+      "mode": "managed",
+      "type": "local_file",
+      "name": "servicio_dummy",
+      "provider": "provider[\"registry.terraform.io/hashicorp/local\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "content": "Servicio creado a las 2025-06-18 23:42:47",
+            "content_base64": null,
+            "content_base64sha256": "62CfQur2e51Bih/AM8FN0iEUlMx5FRulcCaA+QJZTPg=",
+            "content_base64sha512": "Jw+SF+VCsE8xlHgDubxQ2pIHn4RYYWga2m2j7VlToRv1ipUN4UKWB7fagWRxAZ480TJvkSO3ijEw3AiKSjCxIw==",
+            "content_md5": "5bab79ebd68bf1e947569e8e587f165f",
+            "content_sha1": "5bfabda6b02397fb709a162dc4a350bbcac83b8b",
+            "content_sha256": "eb609f42eaf67b9d418a1fc033c14dd2211494cc79151ba5702680f902594cf8",
+            "content_sha512": "270f9217e542b04f31947803b9bc50da92079f845861681ada6da3ed5953a11bf58a950de1429607b7da816471019e3cd1326f9123b78a3130dc088a4a30b123",
+            "directory_permission": "0777",
+            "file_permission": "0777",
+            "filename": "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service",
+            "id": "5bfabda6b02397fb709a162dc4a350bbcac83b8b",
+            "sensitive_content": null,
+            "source": null
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "sensitive_content"
+              }
+            ]
+          ],
+          "identity_schema_version": 0
         }
       ]
     },

--- a/terraform/servicio_b/terraform.tfstate.backup
+++ b/terraform/servicio_b/terraform.tfstate.backup
@@ -1,0 +1,183 @@
+{
+  "version": 4,
+  "terraform_version": "1.12.1",
+  "serial": 8,
+  "lineage": "12b86e99-50d0-b059-56c8-d3b1ed12b791",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "local_file",
+      "name": "servicio_dummy",
+      "provider": "provider[\"registry.terraform.io/hashicorp/local\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "content": "Servicio creado a las 2025-06-18 23:33:49",
+            "content_base64": null,
+            "content_base64sha256": "rTXI6BWePJ8JLJbbe8qLk+sMlngDBeOra1J/mIQB5jA=",
+            "content_base64sha512": "0oXHx5z4d9d8Q0M6r0i7lS07bJApHZmpLYOqMxjtK4jCezBqTMwmwqcSUFPJYFoBP02JCEZdyRk5AE+qb/hedA==",
+            "content_md5": "12a2731dd9a4cf0b2d4aa13e55180a50",
+            "content_sha1": "9fdc6d66258759ec2e006259ac3ca8ea7e08b166",
+            "content_sha256": "ad35c8e8159e3c9f092c96db7bca8b93eb0c96780305e3ab6b527f988401e630",
+            "content_sha512": "d285c7c79cf877d77c43433aaf48bb952d3b6c90291d99a92d83aa3318ed2b88c27b306a4ccc26c2a7125053c9605a013f4d8908465dc91939004faa6ff85e74",
+            "directory_permission": "0777",
+            "file_permission": "0777",
+            "filename": "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_B.service",
+            "id": "9fdc6d66258759ec2e006259ac3ca8ea7e08b166",
+            "sensitive_content": null,
+            "source": null
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "sensitive_content"
+              }
+            ]
+          ],
+          "identity_schema_version": 0
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "servicio_b",
+      "provider": "provider[\"registry.terraform.io/hashicorp/null\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "4364075706985955479",
+            "triggers": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "dependencies": [
+            "module.servicio_c.local_file.db_dummy",
+            "module.servicio_c.module.servicio_a.local_file.servicio_dummy",
+            "module.servicio_c.module.servicio_a.null_resource.servicio_a",
+            "module.servicio_c.null_resource.servicio_c"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.servicio_c",
+      "mode": "managed",
+      "type": "local_file",
+      "name": "db_dummy",
+      "provider": "provider[\"registry.terraform.io/hashicorp/local\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "content": "Base de datos creada a las 2025-06-18 23:33:49",
+            "content_base64": null,
+            "content_base64sha256": "lBf6oPl/JsCep4fvMhKgxaghCa4/dcZFAQu5w5nAYOE=",
+            "content_base64sha512": "NaJGCZDq4G5veIg2qrTBz0YSVLDkdwJgesgIVEeql1+37i5oGFwVGXtHx2SYHYYsc2xd473vnV6x2UiFAMW6Kg==",
+            "content_md5": "3b210843fabafdc6ede3be7a2de617bb",
+            "content_sha1": "eae5884947c2294bbea82a2dbd9672566f91bd32",
+            "content_sha256": "9417faa0f97f26c09ea787ef3212a0c5a82109ae3f75c645010bb9c399c060e1",
+            "content_sha512": "35a2460990eae06e6f788836aab4c1cf461254b0e47702607ac8085447aa975fb7ee2e68185c15197b47c764981d862c736c5de3bdef9d5eb1d9488500c5ba2a",
+            "directory_permission": "0777",
+            "file_permission": "0777",
+            "filename": "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/db_dummy.txt",
+            "id": "eae5884947c2294bbea82a2dbd9672566f91bd32",
+            "sensitive_content": null,
+            "source": null
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "sensitive_content"
+              }
+            ]
+          ],
+          "identity_schema_version": 0
+        }
+      ]
+    },
+    {
+      "module": "module.servicio_c",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "servicio_c",
+      "provider": "provider[\"registry.terraform.io/hashicorp/null\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "4655234923691359330",
+            "triggers": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "dependencies": [
+            "module.servicio_c.module.servicio_a.local_file.servicio_dummy",
+            "module.servicio_c.module.servicio_a.null_resource.servicio_a"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.servicio_c.module.servicio_a",
+      "mode": "managed",
+      "type": "local_file",
+      "name": "servicio_dummy",
+      "provider": "provider[\"registry.terraform.io/hashicorp/local\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "content": "Servicio creado a las 2025-06-18 23:33:49",
+            "content_base64": null,
+            "content_base64sha256": "rTXI6BWePJ8JLJbbe8qLk+sMlngDBeOra1J/mIQB5jA=",
+            "content_base64sha512": "0oXHx5z4d9d8Q0M6r0i7lS07bJApHZmpLYOqMxjtK4jCezBqTMwmwqcSUFPJYFoBP02JCEZdyRk5AE+qb/hedA==",
+            "content_md5": "12a2731dd9a4cf0b2d4aa13e55180a50",
+            "content_sha1": "9fdc6d66258759ec2e006259ac3ca8ea7e08b166",
+            "content_sha256": "ad35c8e8159e3c9f092c96db7bca8b93eb0c96780305e3ab6b527f988401e630",
+            "content_sha512": "d285c7c79cf877d77c43433aaf48bb952d3b6c90291d99a92d83aa3318ed2b88c27b306a4ccc26c2a7125053c9605a013f4d8908465dc91939004faa6ff85e74",
+            "directory_permission": "0777",
+            "file_permission": "0777",
+            "filename": "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service",
+            "id": "9fdc6d66258759ec2e006259ac3ca8ea7e08b166",
+            "sensitive_content": null,
+            "source": null
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "sensitive_content"
+              }
+            ]
+          ],
+          "identity_schema_version": 0
+        }
+      ]
+    },
+    {
+      "module": "module.servicio_c.module.servicio_a",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "servicio_a",
+      "provider": "provider[\"registry.terraform.io/hashicorp/null\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "8290191218549315080",
+            "triggers": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0
+        }
+      ]
+    }
+  ],
+  "check_results": null
+}

--- a/terraform/servicio_c/.terraform.lock.hcl
+++ b/terraform/servicio_c/.terraform.lock.hcl
@@ -1,6 +1,25 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.5.3"
+  hashes = [
+    "h1:1Nkh16jQJMp0EuDmvP/96f5Unnir0z12WyDuoR6HjMo=",
+    "zh:284d4b5b572eacd456e605e94372f740f6de27b71b4e1fd49b63745d8ecd4927",
+    "zh:40d9dfc9c549e406b5aab73c023aa485633c1b6b730c933d7bcc2fa67fd1ae6e",
+    "zh:6243509bb208656eb9dc17d3c525c89acdd27f08def427a0dce22d5db90a4c8b",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:885d85869f927853b6fe330e235cd03c337ac3b933b0d9ae827ec32fa1fdcdbf",
+    "zh:bab66af51039bdfcccf85b25fe562cbba2f54f6b3812202f4873ade834ec201d",
+    "zh:c505ff1bf9442a889ac7dca3ac05a8ee6f852e0118dd9a61796a2f6ff4837f09",
+    "zh:d36c0b5770841ddb6eaf0499ba3de48e5d4fc99f4829b6ab66b0fab59b1aaf4f",
+    "zh:ddb6a407c7f3ec63efb4dad5f948b54f7f4434ee1a2607a49680d494b1776fe1",
+    "zh:e0dafdd4500bec23d3ff221e3a9b60621c5273e5df867bc59ef6b7e41f5c91f6",
+    "zh:ece8742fd2882a8fc9d6efd20e2590010d43db386b920b2a9c220cfecc18de47",
+    "zh:f4c6b3eb8f39105004cf720e202f04f57e3578441cfb76ca27611139bc116a82",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/null" {
   version = "3.2.4"
   hashes = [

--- a/terraform/servicio_c/.terraform/providers/registry.terraform.io/hashicorp/local/2.5.3/linux_amd64/LICENSE.txt
+++ b/terraform/servicio_c/.terraform/providers/registry.terraform.io/hashicorp/local/2.5.3/linux_amd64/LICENSE.txt
@@ -1,0 +1,375 @@
+Copyright (c) 2017 HashiCorp, Inc.
+
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/terraform/servicio_c/main.tf
+++ b/terraform/servicio_c/main.tf
@@ -8,7 +8,7 @@ locals {
 
   ruta_raiz_proyecto       = abspath("${path.module}/../../")
   ruta_servicios_simulados = abspath("${path.module}/../../servicios_simulados")
-
+  hora_local               = timeadd(timestamp(), "-5h")
 }
 
 # variable ruta_raiz_proyecto {
@@ -21,6 +21,10 @@ locals {
 #   type = string
 # }
 
+resource "local_file" "db_dummy" {
+  filename = "${local.ruta_servicios_simulados}/db_dummy.txt"
+  content  = "Base de datos creada a las ${formatdate("YYYY-MM-DD hh:mm:ss", local.hora_local)}"
+}
 
 resource "null_resource" "servicio_c" {
 

--- a/terraform/servicio_c/terraform.tfstate
+++ b/terraform/servicio_c/terraform.tfstate
@@ -1,10 +1,46 @@
 {
   "version": 4,
   "terraform_version": "1.12.1",
-  "serial": 3,
+  "serial": 9,
   "lineage": "bc927bc3-aa48-2a05-a338-fbd74c67f61b",
   "outputs": {},
   "resources": [
+    {
+      "mode": "managed",
+      "type": "local_file",
+      "name": "db_dummy",
+      "provider": "provider[\"registry.terraform.io/hashicorp/local\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "content": "Base de datos creada a las 2025-06-18 23:42:45",
+            "content_base64": null,
+            "content_base64sha256": "crqxgU1wbMturENoEzZqcR4VvwmO+aIudat5dfBl++A=",
+            "content_base64sha512": "3zOAx199bMfRyONUJ/L2deLDkrqKgAxf+dyxj7GGObI6NvQTofH1lhSVeXIqb7rfWv1zXumhNnv3FaTucMFxVQ==",
+            "content_md5": "2c2a9e12a979ac89344fa977b95db16d",
+            "content_sha1": "7453bf338c6135145aeb26a89cc8b5359fc5098b",
+            "content_sha256": "72bab1814d706ccb6eac436813366a711e15bf098ef9a22e75ab7975f065fbe0",
+            "content_sha512": "df3380c75f7d6cc7d1c8e35427f2f675e2c392ba8a800c5ff9dcb18fb18639b23a36f413a1f1f596149579722a6fbadf5afd735ee9a1367bf715a4ee70c17155",
+            "directory_permission": "0777",
+            "file_permission": "0777",
+            "filename": "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/db_dummy.txt",
+            "id": "7453bf338c6135145aeb26a89cc8b5359fc5098b",
+            "sensitive_content": null,
+            "source": null
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "sensitive_content"
+              }
+            ]
+          ],
+          "identity_schema_version": 0
+        }
+      ]
+    },
     {
       "mode": "managed",
       "type": "null_resource",
@@ -20,8 +56,46 @@
           "sensitive_attributes": [],
           "identity_schema_version": 0,
           "dependencies": [
+            "module.servicio_a.local_file.servicio_dummy",
             "module.servicio_a.null_resource.servicio_a"
           ]
+        }
+      ]
+    },
+    {
+      "module": "module.servicio_a",
+      "mode": "managed",
+      "type": "local_file",
+      "name": "servicio_dummy",
+      "provider": "provider[\"registry.terraform.io/hashicorp/local\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "content": "Servicio creado a las 2025-06-18 23:42:45",
+            "content_base64": null,
+            "content_base64sha256": "uvIf7hOIGmKnehuh+W4iqxJ4SPTDt8ZHpF7HT032qjs=",
+            "content_base64sha512": "OyCDUT1GAGZJKHTBiRusFwjUoankvON1q4dDbzeaiWhzgDDo7+JVxI5KD4FGkplsxCHKXZXBRbQX8+hqZBRnxg==",
+            "content_md5": "1cc0ab2a2ec34171087e38116c26ce17",
+            "content_sha1": "a38f5d913f0220adee4b3add1bd28554c162c225",
+            "content_sha256": "baf21fee13881a62a77a1ba1f96e22ab127848f4c3b7c647a45ec74f4df6aa3b",
+            "content_sha512": "3b2083513d460066492874c1891bac1708d4a1a9e4bce375ab87436f379a8968738030e8efe255c48e4a0f814692996cc421ca5d95c145b417f3e86a641467c6",
+            "directory_permission": "0777",
+            "file_permission": "0777",
+            "filename": "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service",
+            "id": "a38f5d913f0220adee4b3add1bd28554c162c225",
+            "sensitive_content": null,
+            "source": null
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "sensitive_content"
+              }
+            ]
+          ],
+          "identity_schema_version": 0
         }
       ]
     },

--- a/terraform/servicio_c/terraform.tfstate
+++ b/terraform/servicio_c/terraform.tfstate
@@ -2,7 +2,7 @@
   "version": 4,
   "terraform_version": "1.12.1",
   "serial": 3,
-  "lineage": "68a5de65-0b11-9ebb-361c-8698b2ca077c",
+  "lineage": "bc927bc3-aa48-2a05-a338-fbd74c67f61b",
   "outputs": {},
   "resources": [
     {
@@ -14,7 +14,7 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "2970829238635209918",
+            "id": "5189715582138057298",
             "triggers": null
           },
           "sensitive_attributes": [],
@@ -35,7 +35,7 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "5551887673039675110",
+            "id": "7594903794493526689",
             "triggers": null
           },
           "sensitive_attributes": [],

--- a/terraform/servicio_c/terraform.tfstate.backup
+++ b/terraform/servicio_c/terraform.tfstate.backup
@@ -1,0 +1,122 @@
+{
+  "version": 4,
+  "terraform_version": "1.12.1",
+  "serial": 6,
+  "lineage": "bc927bc3-aa48-2a05-a338-fbd74c67f61b",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "local_file",
+      "name": "db_dummy",
+      "provider": "provider[\"registry.terraform.io/hashicorp/local\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "content": "Base de datos creada a las 2025-06-18 23:33:48",
+            "content_base64": null,
+            "content_base64sha256": "scuIVck2cqtu/oQjTrh/vwrDq3Aoxne9dZywpTlw0mo=",
+            "content_base64sha512": "Lbvck+G/s8xiJF+Q7iwQgJE+O4Zz7pdzLDpaPxl2oYIBUzjbPJ3CvwUSVVKeUTVQxh/X2PYf7+fBRsfn1i+mQw==",
+            "content_md5": "83e833024c99207931048d90027a8e7c",
+            "content_sha1": "9ebf5578bc9c60a6f024253e51df11f8f6559878",
+            "content_sha256": "b1cb8855c93672ab6efe84234eb87fbf0ac3ab7028c677bd759cb0a53970d26a",
+            "content_sha512": "2dbbdc93e1bfb3cc62245f90ee2c1080913e3b8673ee97732c3a5a3f1976a182015338db3c9dc2bf051255529e513550c61fd7d8f61fefe7c146c7e7d62fa643",
+            "directory_permission": "0777",
+            "file_permission": "0777",
+            "filename": "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/db_dummy.txt",
+            "id": "9ebf5578bc9c60a6f024253e51df11f8f6559878",
+            "sensitive_content": null,
+            "source": null
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "sensitive_content"
+              }
+            ]
+          ],
+          "identity_schema_version": 0
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "servicio_c",
+      "provider": "provider[\"registry.terraform.io/hashicorp/null\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "5189715582138057298",
+            "triggers": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "dependencies": [
+            "module.servicio_a.local_file.servicio_dummy",
+            "module.servicio_a.null_resource.servicio_a"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.servicio_a",
+      "mode": "managed",
+      "type": "local_file",
+      "name": "servicio_dummy",
+      "provider": "provider[\"registry.terraform.io/hashicorp/local\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "content": "Servicio creado a las 2025-06-18 23:33:48",
+            "content_base64": null,
+            "content_base64sha256": "vFUGL6PhOT3f40/sKER+bek/Di/zpap4WbyvYdOyYPM=",
+            "content_base64sha512": "owxfPqvl7ztR98++g3CFX6b7uW2t9RZLA4toF6lJtzvVIYrKrLF7VXvWXdf/Vwnm+xNsllIfkN8UHrtxocbNOA==",
+            "content_md5": "e1b25f14535d793246342633f6dd4b5e",
+            "content_sha1": "5b2b65cab73981cbeb0def8932cecedb3ff375cd",
+            "content_sha256": "bc55062fa3e1393ddfe34fec28447e6de93f0e2ff3a5aa7859bcaf61d3b260f3",
+            "content_sha512": "a30c5f3eabe5ef3b51f7cfbe8370855fa6fbb96dadf5164b038b6817a949b73bd5218acaacb17b557bd65dd7ff5709e6fb136c96521f90df141ebb71a1c6cd38",
+            "directory_permission": "0777",
+            "file_permission": "0777",
+            "filename": "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service",
+            "id": "5b2b65cab73981cbeb0def8932cecedb3ff375cd",
+            "sensitive_content": null,
+            "source": null
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "sensitive_content"
+              }
+            ]
+          ],
+          "identity_schema_version": 0
+        }
+      ]
+    },
+    {
+      "module": "module.servicio_a",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "servicio_a",
+      "provider": "provider[\"registry.terraform.io/hashicorp/null\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "7594903794493526689",
+            "triggers": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0
+        }
+      ]
+    }
+  ],
+  "check_results": null
+}

--- a/terraform/servicio_d/.terraform.lock.hcl
+++ b/terraform/servicio_d/.terraform.lock.hcl
@@ -1,6 +1,25 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.5.3"
+  hashes = [
+    "h1:1Nkh16jQJMp0EuDmvP/96f5Unnir0z12WyDuoR6HjMo=",
+    "zh:284d4b5b572eacd456e605e94372f740f6de27b71b4e1fd49b63745d8ecd4927",
+    "zh:40d9dfc9c549e406b5aab73c023aa485633c1b6b730c933d7bcc2fa67fd1ae6e",
+    "zh:6243509bb208656eb9dc17d3c525c89acdd27f08def427a0dce22d5db90a4c8b",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:885d85869f927853b6fe330e235cd03c337ac3b933b0d9ae827ec32fa1fdcdbf",
+    "zh:bab66af51039bdfcccf85b25fe562cbba2f54f6b3812202f4873ade834ec201d",
+    "zh:c505ff1bf9442a889ac7dca3ac05a8ee6f852e0118dd9a61796a2f6ff4837f09",
+    "zh:d36c0b5770841ddb6eaf0499ba3de48e5d4fc99f4829b6ab66b0fab59b1aaf4f",
+    "zh:ddb6a407c7f3ec63efb4dad5f948b54f7f4434ee1a2607a49680d494b1776fe1",
+    "zh:e0dafdd4500bec23d3ff221e3a9b60621c5273e5df867bc59ef6b7e41f5c91f6",
+    "zh:ece8742fd2882a8fc9d6efd20e2590010d43db386b920b2a9c220cfecc18de47",
+    "zh:f4c6b3eb8f39105004cf720e202f04f57e3578441cfb76ca27611139bc116a82",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/null" {
   version = "3.2.4"
   hashes = [

--- a/terraform/servicio_d/.terraform/providers/registry.terraform.io/hashicorp/local/2.5.3/linux_amd64/LICENSE.txt
+++ b/terraform/servicio_d/.terraform/providers/registry.terraform.io/hashicorp/local/2.5.3/linux_amd64/LICENSE.txt
@@ -1,0 +1,375 @@
+Copyright (c) 2017 HashiCorp, Inc.
+
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/terraform/servicio_d/terraform.tfstate
+++ b/terraform/servicio_d/terraform.tfstate
@@ -1,7 +1,7 @@
 {
   "version": 4,
   "terraform_version": "1.12.1",
-  "serial": 5,
+  "serial": 13,
   "lineage": "0d12cb95-1416-4f46-8107-b28178cd7ae3",
   "outputs": {},
   "resources": [
@@ -20,10 +20,50 @@
           "sensitive_attributes": [],
           "identity_schema_version": 0,
           "dependencies": [
+            "module.servicio_b.local_file.servicio_dummy",
+            "module.servicio_b.module.servicio_c.local_file.db_dummy",
+            "module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy",
             "module.servicio_b.module.servicio_c.module.servicio_a.null_resource.servicio_a",
             "module.servicio_b.module.servicio_c.null_resource.servicio_c",
             "module.servicio_b.null_resource.servicio_b"
           ]
+        }
+      ]
+    },
+    {
+      "module": "module.servicio_b",
+      "mode": "managed",
+      "type": "local_file",
+      "name": "servicio_dummy",
+      "provider": "provider[\"registry.terraform.io/hashicorp/local\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "content": "Servicio creado a las 2025-06-18 23:42:49",
+            "content_base64": null,
+            "content_base64sha256": "s9bBpCZm7dd7RoCc9KKBoNhOdxpLV39OoRriHvqTfj8=",
+            "content_base64sha512": "MqKvYYpdHecx4Q6bXlNoL/heid9pfvFjJolhvBubtVLlxlFvmuPcdiEpTp5zykAruFsNTjKWp86KjGzpLlMtyQ==",
+            "content_md5": "98275962346709efa1fb90cb6dde564c",
+            "content_sha1": "9cb27978bc2cf5bd5cc35f5ef637fda3e9fdd6a2",
+            "content_sha256": "b3d6c1a42666edd77b46809cf4a281a0d84e771a4b577f4ea11ae21efa937e3f",
+            "content_sha512": "32a2af618a5d1de731e10e9b5e53682ff85e89df697ef163268961bc1b9bb552e5c6516f9ae3dc7621294e9e73ca402bb85b0d4e3296a7ce8a8c6ce92e532dc9",
+            "directory_permission": "0777",
+            "file_permission": "0777",
+            "filename": "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_B.service",
+            "id": "9cb27978bc2cf5bd5cc35f5ef637fda3e9fdd6a2",
+            "sensitive_content": null,
+            "source": null
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "sensitive_content"
+              }
+            ]
+          ],
+          "identity_schema_version": 0
         }
       ]
     },
@@ -43,9 +83,48 @@
           "sensitive_attributes": [],
           "identity_schema_version": 0,
           "dependencies": [
+            "module.servicio_b.module.servicio_c.local_file.db_dummy",
+            "module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy",
             "module.servicio_b.module.servicio_c.module.servicio_a.null_resource.servicio_a",
             "module.servicio_b.module.servicio_c.null_resource.servicio_c"
           ]
+        }
+      ]
+    },
+    {
+      "module": "module.servicio_b.module.servicio_c",
+      "mode": "managed",
+      "type": "local_file",
+      "name": "db_dummy",
+      "provider": "provider[\"registry.terraform.io/hashicorp/local\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "content": "Base de datos creada a las 2025-06-18 23:42:49",
+            "content_base64": null,
+            "content_base64sha256": "7Y+lpGbSdzWKPFZi1hvbNYdhmDMxyEYMyM2mEzMm4kc=",
+            "content_base64sha512": "7vhf2idFcWol9+BLk/LofH543LuNCPD6oD8u9d112Kui3VbIjA0UMGNnXtlJNmnJ/ToEvPbwx4wzbzXMeFVpfA==",
+            "content_md5": "8896bc93716182c02c7ffaa5dbca52bf",
+            "content_sha1": "d811e1a1422bd1bcde4a8740d631a9dbe4a447c4",
+            "content_sha256": "ed8fa5a466d277358a3c5662d61bdb358761983331c8460cc8cda6133326e247",
+            "content_sha512": "eef85fda2745716a25f7e04b93f2e87c7e78dcbb8d08f0faa03f2ef5dd75d8aba2dd56c88c0d143063675ed9493669c9fd3a04bcf6f0c78c336f35cc7855697c",
+            "directory_permission": "0777",
+            "file_permission": "0777",
+            "filename": "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/db_dummy.txt",
+            "id": "d811e1a1422bd1bcde4a8740d631a9dbe4a447c4",
+            "sensitive_content": null,
+            "source": null
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "sensitive_content"
+              }
+            ]
+          ],
+          "identity_schema_version": 0
         }
       ]
     },
@@ -65,8 +144,46 @@
           "sensitive_attributes": [],
           "identity_schema_version": 0,
           "dependencies": [
+            "module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy",
             "module.servicio_b.module.servicio_c.module.servicio_a.null_resource.servicio_a"
           ]
+        }
+      ]
+    },
+    {
+      "module": "module.servicio_b.module.servicio_c.module.servicio_a",
+      "mode": "managed",
+      "type": "local_file",
+      "name": "servicio_dummy",
+      "provider": "provider[\"registry.terraform.io/hashicorp/local\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "content": "Servicio creado a las 2025-06-18 23:42:49",
+            "content_base64": null,
+            "content_base64sha256": "s9bBpCZm7dd7RoCc9KKBoNhOdxpLV39OoRriHvqTfj8=",
+            "content_base64sha512": "MqKvYYpdHecx4Q6bXlNoL/heid9pfvFjJolhvBubtVLlxlFvmuPcdiEpTp5zykAruFsNTjKWp86KjGzpLlMtyQ==",
+            "content_md5": "98275962346709efa1fb90cb6dde564c",
+            "content_sha1": "9cb27978bc2cf5bd5cc35f5ef637fda3e9fdd6a2",
+            "content_sha256": "b3d6c1a42666edd77b46809cf4a281a0d84e771a4b577f4ea11ae21efa937e3f",
+            "content_sha512": "32a2af618a5d1de731e10e9b5e53682ff85e89df697ef163268961bc1b9bb552e5c6516f9ae3dc7621294e9e73ca402bb85b0d4e3296a7ce8a8c6ce92e532dc9",
+            "directory_permission": "0777",
+            "file_permission": "0777",
+            "filename": "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service",
+            "id": "9cb27978bc2cf5bd5cc35f5ef637fda3e9fdd6a2",
+            "sensitive_content": null,
+            "source": null
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "sensitive_content"
+              }
+            ]
+          ],
+          "identity_schema_version": 0
         }
       ]
     },

--- a/terraform/servicio_d/terraform.tfstate
+++ b/terraform/servicio_d/terraform.tfstate
@@ -2,7 +2,7 @@
   "version": 4,
   "terraform_version": "1.12.1",
   "serial": 5,
-  "lineage": "5f839a5d-ed18-772f-d20c-b23a716dc657",
+  "lineage": "0d12cb95-1416-4f46-8107-b28178cd7ae3",
   "outputs": {},
   "resources": [
     {
@@ -14,7 +14,7 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "2149213823221964215",
+            "id": "3446376636890549700",
             "triggers": null
           },
           "sensitive_attributes": [],
@@ -37,7 +37,7 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "7133655055705762577",
+            "id": "7760375672855320056",
             "triggers": null
           },
           "sensitive_attributes": [],
@@ -59,7 +59,7 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "8002457015449453566",
+            "id": "4453232201833176036",
             "triggers": null
           },
           "sensitive_attributes": [],
@@ -80,7 +80,7 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "479148610471189324",
+            "id": "2258264413017640814",
             "triggers": null
           },
           "sensitive_attributes": [],

--- a/terraform/servicio_d/terraform.tfstate.backup
+++ b/terraform/servicio_d/terraform.tfstate.backup
@@ -1,0 +1,210 @@
+{
+  "version": 4,
+  "terraform_version": "1.12.1",
+  "serial": 9,
+  "lineage": "0d12cb95-1416-4f46-8107-b28178cd7ae3",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "servicio_d",
+      "provider": "provider[\"registry.terraform.io/hashicorp/null\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "3446376636890549700",
+            "triggers": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "dependencies": [
+            "module.servicio_b.local_file.servicio_dummy",
+            "module.servicio_b.module.servicio_c.local_file.db_dummy",
+            "module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy",
+            "module.servicio_b.module.servicio_c.module.servicio_a.null_resource.servicio_a",
+            "module.servicio_b.module.servicio_c.null_resource.servicio_c",
+            "module.servicio_b.null_resource.servicio_b"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.servicio_b",
+      "mode": "managed",
+      "type": "local_file",
+      "name": "servicio_dummy",
+      "provider": "provider[\"registry.terraform.io/hashicorp/local\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "content": "Servicio creado a las 2025-06-18 23:33:50",
+            "content_base64": null,
+            "content_base64sha256": "pUrBRas/HAG86DrylSmlU20KrOuXWqVOkMSzjBZaz5Y=",
+            "content_base64sha512": "44rmWIn90l0vPL+jqh1ctpINhumT2lRryI1vwQNNBOGE5pwbfV9sn173qsqm7c4+CWXGU4X5gSvVJgvgyu+mqw==",
+            "content_md5": "04ddae929063bab6101a37c79d971743",
+            "content_sha1": "b96e6520a3032c904821db79a9af93276cae971d",
+            "content_sha256": "a54ac145ab3f1c01bce83af29529a5536d0aaceb975aa54e90c4b38c165acf96",
+            "content_sha512": "e38ae65889fdd25d2f3cbfa3aa1d5cb6920d86e993da546bc88d6fc1034d04e184e69c1b7d5f6c9f5ef7aacaa6edce3e0965c65385f9812bd5260be0caefa6ab",
+            "directory_permission": "0777",
+            "file_permission": "0777",
+            "filename": "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_B.service",
+            "id": "b96e6520a3032c904821db79a9af93276cae971d",
+            "sensitive_content": null,
+            "source": null
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "sensitive_content"
+              }
+            ]
+          ],
+          "identity_schema_version": 0
+        }
+      ]
+    },
+    {
+      "module": "module.servicio_b",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "servicio_b",
+      "provider": "provider[\"registry.terraform.io/hashicorp/null\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "7760375672855320056",
+            "triggers": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "dependencies": [
+            "module.servicio_b.module.servicio_c.local_file.db_dummy",
+            "module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy",
+            "module.servicio_b.module.servicio_c.module.servicio_a.null_resource.servicio_a",
+            "module.servicio_b.module.servicio_c.null_resource.servicio_c"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.servicio_b.module.servicio_c",
+      "mode": "managed",
+      "type": "local_file",
+      "name": "db_dummy",
+      "provider": "provider[\"registry.terraform.io/hashicorp/local\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "content": "Base de datos creada a las 2025-06-18 23:33:50",
+            "content_base64": null,
+            "content_base64sha256": "BReavN1YytONmOebtEHVbAzgwVs7gSb2TZ5jhRRPPMk=",
+            "content_base64sha512": "3+F5stCaa4dykRRDxuZZEOb8FoeQenLJy8514jSSzsLv5lB5vaHCaCwzutIrckNlLeDHo2/gxbPy6NXmWyVpIQ==",
+            "content_md5": "a3fff9152ba9292ced560781003c2381",
+            "content_sha1": "3d2c379ad974f5b05396ed071277eda29fdd19d6",
+            "content_sha256": "05179abcdd58cad38d98e79bb441d56c0ce0c15b3b8126f64d9e6385144f3cc9",
+            "content_sha512": "dfe179b2d09a6b8772911443c6e65910e6fc1687907a72c9cbce75e23492cec2efe65079bda1c2682c33bad22b7243652de0c7a36fe0c5b3f2e8d5e65b256921",
+            "directory_permission": "0777",
+            "file_permission": "0777",
+            "filename": "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/db_dummy.txt",
+            "id": "3d2c379ad974f5b05396ed071277eda29fdd19d6",
+            "sensitive_content": null,
+            "source": null
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "sensitive_content"
+              }
+            ]
+          ],
+          "identity_schema_version": 0
+        }
+      ]
+    },
+    {
+      "module": "module.servicio_b.module.servicio_c",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "servicio_c",
+      "provider": "provider[\"registry.terraform.io/hashicorp/null\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "4453232201833176036",
+            "triggers": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "dependencies": [
+            "module.servicio_b.module.servicio_c.module.servicio_a.local_file.servicio_dummy",
+            "module.servicio_b.module.servicio_c.module.servicio_a.null_resource.servicio_a"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.servicio_b.module.servicio_c.module.servicio_a",
+      "mode": "managed",
+      "type": "local_file",
+      "name": "servicio_dummy",
+      "provider": "provider[\"registry.terraform.io/hashicorp/local\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "content": "Servicio creado a las 2025-06-18 23:33:50",
+            "content_base64": null,
+            "content_base64sha256": "pUrBRas/HAG86DrylSmlU20KrOuXWqVOkMSzjBZaz5Y=",
+            "content_base64sha512": "44rmWIn90l0vPL+jqh1ctpINhumT2lRryI1vwQNNBOGE5pwbfV9sn173qsqm7c4+CWXGU4X5gSvVJgvgyu+mqw==",
+            "content_md5": "04ddae929063bab6101a37c79d971743",
+            "content_sha1": "b96e6520a3032c904821db79a9af93276cae971d",
+            "content_sha256": "a54ac145ab3f1c01bce83af29529a5536d0aaceb975aa54e90c4b38c165acf96",
+            "content_sha512": "e38ae65889fdd25d2f3cbfa3aa1d5cb6920d86e993da546bc88d6fc1034d04e184e69c1b7d5f6c9f5ef7aacaa6edce3e0965c65385f9812bd5260be0caefa6ab",
+            "directory_permission": "0777",
+            "file_permission": "0777",
+            "filename": "/home/dirac/Documents/DS/GitOps-Local/servicios_simulados/servicio_dummy_A.service",
+            "id": "b96e6520a3032c904821db79a9af93276cae971d",
+            "sensitive_content": null,
+            "source": null
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "sensitive_content"
+              }
+            ]
+          ],
+          "identity_schema_version": 0
+        }
+      ]
+    },
+    {
+      "module": "module.servicio_b.module.servicio_c.module.servicio_a",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "servicio_a",
+      "provider": "provider[\"registry.terraform.io/hashicorp/null\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "2258264413017640814",
+            "triggers": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0
+        }
+      ]
+    }
+  ],
+  "check_results": null
+}


### PR DESCRIPTION
Se agrego script `rollback.sh` y script de soporte `guarda_tag_state.sh`. Lo que permite restaurar el estado de los modulos de Terraform a un estado dado un tag de Git.

Adicinalmente, se esta subiendo 
- Archivos de configuracion de Terraform para su versionado (`tfstate`)
- Archivo `.gitignore`
- Directorio backups con archivos `tfstate` dado un tag especifico

Closes #25 
